### PR TITLE
helpers action parameter can be strict typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
 ## 1.0.5
 
 - Initial version
@@ -40,3 +43,6 @@ No changes yet.
 
 - Documentation fix.
 
+## 1.1.16
+
+- Effect helpers action parameter can be dynamic or strict typed

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -12,14 +12,9 @@ bool _isFunctionVoid(Function f) {
       closure.contains(') => Future<Null>');
 }
 
-bool _functionHasNamedArgument(Function f, String type, String name) {
-  if (f == null) throw CannotDetermineNullFunctionArguments();
-  var closure = f.toString();
-  return closure.contains('{$type $name}');
-}
-
 bool _functionHasActionArgument(Function f) {
-  return _functionHasNamedArgument(f, 'dynamic', 'action');
+  var closure = f.toString();
+  return closure.contains(' action}') || closure.contains(' action,');
 }
 
 dynamic _callFunctionWithArgument(Function f, List<dynamic> args,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: redux_saga
 maintainer: Bilal Uslu (@bilaluslu)
 description: redux_saga is a library that aims to make application side effects easier to manage, more efficient to execute, easy to test, and better at handling failures.
 homepage: https://github.com/reduxsaga/redux_saga
-version: 1.1.15
+version: 1.1.16
 repository: https://github.com/reduxsaga/redux_saga
 
 environment:


### PR DESCRIPTION
If you have guaranteed your saga will take only one specific type or its derivatives then you can use "usage 2", otherwise it is better to use "usage 1"

//usage 1
fetchUser({dynamic action}) sync* {
...
}

//usage 2
fetchUser({UserFetchRequested action}) sync* {
...
}

mySaga() sync* {
  yield TakeEvery(fetchUser, pattern: UserFetchRequested);
}
