### PR TITLE
fixed flutter web build closure mismatch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,50 @@ No changes yet.
 ## 1.1.16
 
 - Effect helpers action parameter can be dynamic or strict typed
+
+## 2.0.0
+
+- Flutter web build errors fixed. After minification the function closures are changing.
+In order to avoid dart mirrors usage (also not avaliable) some changes are made.
+Codes are written at previous versions of the library must be migrated to this version.
+Please use the following instructions;
+
+1. If you use one of the effects Debounce, TakeEvery, TakeLatest, TakeLeading or Throttle then you must add named `action` parameter to the saga.
+Otherwise a parameter mismatch error may occured like the following;
+
+Dynamic call with unexpected named argument 'action'.
+
+Proper usage example :
+
+```
+fetchUser({dynamic action}) sync* { //add `{dynamic action}` as parameter
+    //...
+}
+
+mySaga() sync* {
+  yield TakeEvery(fetchUser, pattern: UserFetchRequested);
+}
+```
+
+2. Catch saga of Try effect must have error and stackTrace arguments.
+Otherwise a parameter mismatch error may occured like the following;
+
+Dynamic call with too many arguments.
+Receiver: Instance of '() => Iterable<Null>'
+Arguments: [Instance of '_Exception', Instance of '_StackTrace']
+
+
+Proper usage example :
+
+```
+  //...
+
+  yield Try(() sync* {
+
+  }, Catch: (e, s) sync* {  //add e and s parameters to saga
+
+  });
+
+  //...
+```
+

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ fetchUser({dynamic action}) sync* {
     var user = Result();
     yield Call(Api.fetchUser, args: [action.payload.userId], result: user);
     yield Put(UserFetchSuceeded(user: user.value));
-  }, Catch: (e) sync* {
+  }, Catch: (e, s) sync* {
     yield Put(UserFetchFailed(message: e.message));
   });
 }

--- a/doc/advanced/ForkModel.md
+++ b/doc/advanced/ForkModel.md
@@ -123,7 +123,7 @@ fetchResource(resource) sync* {
 mainSaga() sync* {
   yield Try(() sync* {
     yield Call(fetchAll);
-  }, Catch: (e) sync* {
+  }, Catch: (e, s) sync* {
     // handle fetchAll errors
   });
 }

--- a/doc/advanced/NonBlockingCalls.md
+++ b/doc/advanced/NonBlockingCalls.md
@@ -37,8 +37,8 @@ authorize(user, password) sync* {
     yield Call(Api.authorize, args: [user, password], result: token);
     yield Put(LoginSuccess(token.value));
     yield Return(token);
-  }, Catch: (error) sync* {
-    yield Put(LoginError(error));
+  }, Catch: (e, s) sync* {
+    yield Put(LoginError(e));
   });
 }
 
@@ -146,8 +146,8 @@ authorize(user, password) sync* {
     yield Put(LoginSuccess(token.value));
     yield Call(Api.storeItem, args: [token.value]);
     yield Return(token);
-  }, Catch: (error) sync* {
-    yield Put(LoginError(error));
+  }, Catch: (e, s) sync* {
+    yield Put(LoginError(e));
   });
 }
 
@@ -221,8 +221,8 @@ authorize(user, password) sync* {
     yield Put(LoginSuccess(token.value));
     yield Call(Api.storeItem, args: [token.value]);
     yield Return(token);
-  }, Catch: (error) sync* {
-    yield Put(LoginError(error));
+  }, Catch: (e, s) sync* {
+    yield Put(LoginError(e));
   }, Finally: () sync* {
     var cancelled = Result<bool>();
     yield Cancelled(result: cancelled);

--- a/doc/advanced/RootSaga.md
+++ b/doc/advanced/RootSaga.md
@@ -113,7 +113,7 @@ rootSaga() sync* {
           yield Try(() sync* {
             yield Call(saga);
             success = true;
-          }, Catch: (e) {
+          }, Catch: (e, s) {
             print(e);
           });
           if (success) break;

--- a/doc/advanced/Testing.md
+++ b/doc/advanced/Testing.md
@@ -174,7 +174,7 @@ callApi(url) sync* {
     yield Call(myApi, args: [url, someValue.value], result: resultJson);
     yield Put(SuccessAction(resultJson.value.json()));
     yield Return(resultJson.value.status);
-  }, Catch: (e) sync* {
+  }, Catch: (e, s) sync* {
     yield Put(ErrorAction(e));
     yield Return(-1);
   });
@@ -245,7 +245,7 @@ callApi(url) sync* {
     yield Call(myApi, args: [url, someValue.value], result: resultJson);
     yield Put(SuccessAction(resultJson.value.json()));
     yield Return(resultJson.value.status);
-  }, Catch: (e) sync* {
+  }, Catch: (e, s) sync* {
     yield Put(ErrorAction(e));
     yield Return(-1);
   });

--- a/doc/basics/DeclarativeEffects.md
+++ b/doc/basics/DeclarativeEffects.md
@@ -16,7 +16,7 @@ watchFetchProducts() sync* {
   yield TakeEvery(fetchProducts, pattern: ProductsRequested);
 }
 
-fetchProducts() sync* {
+fetchProducts({dynamic action}) sync* {
   var products = Result();
   yield Call(() => Api.fetch('/products'), result: products);
   print(products.value);
@@ -66,7 +66,7 @@ For this reason, the library provides a different way to perform asynchronous ca
 import 'package:redux_saga/redux_saga.dart';
 import 'api.dart';
 
-fetchProducts() sync* {
+fetchProducts({dynamic action}) sync* {
   var products = Result();
   yield Call(Api.fetch, args: ['/products'], result: products);
   // ...

--- a/doc/basics/ErrorHandling.md
+++ b/doc/basics/ErrorHandling.md
@@ -17,8 +17,8 @@ fetchProducts() sync* {
     var products = Result();
     yield Call(Api.fetch, args: ['/products'], result: products);
     yield Put(ProductsReceived(products.value));
-  }, Catch: (error) sync* {
-    yield Put(ProductsRequestFailed(error));
+  }, Catch: (e, s) sync* {
+    yield Put(ProductsRequestFailed(e));
   });
 }
 ```
@@ -70,7 +70,7 @@ void main() {
       expect(iteratorTry.moveNext(), false, reason: 'fetchProducts Try Saga must be done');
 
       //get Catch iterator with a fake error
-      var iteratorCatch = iterator.current.Catch(Exception('fake')).iterator;
+      var iteratorCatch = iterator.current.Catch(Exception('fake'), null).iterator;
 
       iteratorCatch.moveNext();
 

--- a/doc/basics/UsingSagaHelpers.md
+++ b/doc/basics/UsingSagaHelpers.md
@@ -14,13 +14,13 @@ First we create the task that will perform the asynchronous action:
 import 'package:redux_saga/redux_saga.dart';
 import 'api.dart';
 
-fetchData(action) sync* {
+fetchData({dynamic action}) sync* {
   yield Try(() sync* {
     var data = Result();
     yield Call(Api.fetchUser, args: [action.payload.url], result: data);
     yield Put(FetchSucceed(data.value));
-  }, Catch: (error) sync* {
-    yield Put(FetchFailed(error));
+  }, Catch: (e, s) sync* {
+    yield Put(FetchFailed(e));
   });
 }
 ```
@@ -57,10 +57,10 @@ For example:
 import 'package:redux_saga/redux_saga.dart';
 
 // FetchUsers
-fetchUsers(action) sync* { ... }
+fetchUsers({dynamic action}) sync* { ... }
 
 // CreateUser
-createUser(action) sync* { ... }
+createUser({dynamic action}) sync* { ... }
 
 // use them in parallel
 rootSaga() sync* {

--- a/doc/introduction/BeginnerTutorial.md
+++ b/doc/introduction/BeginnerTutorial.md
@@ -199,7 +199,7 @@ Future<bool> delay(Duration duration) {
 }
 
 // Our worker Saga: will perform the async increment task
-incrementAsync() sync* {
+incrementAsync({dynamic action}) sync* {
   yield delay(Duration(seconds: 1));
   yield Put(IncrementAction());
 }
@@ -238,7 +238,7 @@ Future delay(Duration duration) {
   return Future.delayed(duration, () => true);
 }
 
-incrementAsync() sync* {
+incrementAsync({dynamic action}) sync* {
   yield delay(Duration(seconds: 1));
   yield Put(IncrementAction());
 }
@@ -286,7 +286,7 @@ Now, lets remove the `delay` function and use effect. To use effect just change 
 
 ...
 
-incrementAsync() sync* {
+incrementAsync({dynamic action}) sync* {
   yield Delay(Duration(seconds: 1));
   yield Put(IncrementAction());
 }

--- a/doc/migration/README.md
+++ b/doc/migration/README.md
@@ -123,8 +123,8 @@ checkout() sync* {
     yield Select(selector: getCart, result: cart);
     yield Call(buyProductsAPI, args: [cart.value]);
     yield Put(CheckoutSuccess(cart.value));
-  }, Catch: (error) sync* {
-    yield Put(CheckoutFailure(error));
+  }, Catch: (e, s) sync* {
+    yield Put(CheckoutFailure(e, s));
   }, Finally: () sync* {
     yield Put(CheckoutEnd());
   });
@@ -143,7 +143,7 @@ If you want to return from a returned value from a Try/Catch/Finally block then 
     yield TryReturn(() sync* { //returns saga
       //...
       yield Return(somevalue1); //returns from Try. Does not return from saga
-    }, Catch: (error) sync* {
+    }, Catch: (e, s) sync* {
       //...
       yield Return(somevalue2); //returns from Try. Does not return from saga
     });
@@ -158,7 +158,7 @@ Equivalent code with `Try`
     yield Try(() sync* {
       //...
       yield Return(somevalue1); //returns from Try. Does not return from saga
-    }, Catch: (error) sync* {
+    }, Catch: (e, s) sync* {
       //...
       yield Return(somevalue2); //returns from Try. Does not return from saga
     }, result: result);

--- a/example/main.dart
+++ b/example/main.dart
@@ -21,7 +21,7 @@ class DecrementAction {}
 class IncrementAsyncAction {}
 
 //incrementAsync Saga increasing count delayed
-Iterable incrementAsync() sync* {
+Iterable incrementAsync({dynamic action}) sync* {
   yield Delay(Duration(seconds: 1));
   yield Put(IncrementAction());
 }

--- a/lib/src/effects/cancel.dart
+++ b/lib/src/effects/cancel.dart
@@ -76,7 +76,7 @@ part of redux_saga;
 ///      if (result.value == deny) {
 ///        yield Cancel();
 ///      }
-///    }, Catch: (e) {
+///    }, Catch: (e, s) {
 ///      // handle failure
 ///    }, Finally: () sync* {
 ///      var cancelled = Result();

--- a/lib/src/effects/debounce.dart
+++ b/lib/src/effects/debounce.dart
@@ -120,9 +120,7 @@ Iterable<Effect> _Debounce(Function saga,
       if (raceResult.key == #debounced) {
         yield Fork(saga,
             args: args,
-            namedArgs: _functionHasActionArgument(saga)
-                ? <Symbol, dynamic>{...?namedArgs, #action: action}
-                : namedArgs,
+            namedArgs: <Symbol, dynamic>{...?namedArgs, #action: action},
             Catch: Catch,
             Finally: Finally,
             name: name);

--- a/lib/src/effects/retry.dart
+++ b/lib/src/effects/retry.dart
@@ -36,8 +36,8 @@ part of redux_saga;
 ///        result: response,
 ///      );
 ///      yield Put(RequestSuccess(payload: response.value));
-///    }, Catch: (error) sync* {
-///      yield Put(RequestFail(payload: error));
+///    }, Catch: (e, s) sync* {
+///      yield Put(RequestFail(payload: e));
 ///    });
 ///  }
 ///```
@@ -77,7 +77,8 @@ Iterable<Effect> _Retry(Function fn,
   var triesLeft = maxTries;
   while (true) {
     var failed = false;
-    yield Call(fn, args: args, namedArgs: namedArgs, Catch: () {
+    yield Call(fn, args: args, namedArgs: namedArgs,
+        Catch: (dynamic e, StackTrace s) {
       triesLeft--;
       if (triesLeft <= 0) {
         throw sagaError;

--- a/lib/src/effects/takeEvery.dart
+++ b/lib/src/effects/takeEvery.dart
@@ -33,7 +33,7 @@ part of redux_saga;
 ///
 ///  //...
 ///
-///  fetchUser(action) sync* {
+///  fetchUser({dynamic action}) sync* {
 ///    // ...
 ///  }
 ///
@@ -92,12 +92,10 @@ Iterable<Effect> _TakeEvery(Function saga,
 
     yield Fork(saga,
         args: args,
-        namedArgs: _functionHasActionArgument(saga)
-            ? <Symbol, dynamic>{
-                ...?namedArgs,
-                #action: action is Result ? action.value : action
-              }
-            : namedArgs,
+        namedArgs: <Symbol, dynamic>{
+          ...?namedArgs,
+          #action: action is Result ? action.value : action
+        },
         Catch: Catch,
         Finally: Finally,
         name: name);

--- a/lib/src/effects/takeLatest.dart
+++ b/lib/src/effects/takeLatest.dart
@@ -39,7 +39,7 @@ part of redux_saga;
 ///
 ///  //...
 ///
-///  fetchUser(action) sync* {
+///  fetchUser({dynamic action}) sync* {
 ///    // ...
 ///  }
 ///
@@ -97,12 +97,10 @@ Iterable<Effect> _TakeLatest(Function saga,
 
     yield Fork(saga,
         args: args,
-        namedArgs: _functionHasActionArgument(saga)
-            ? <Symbol, dynamic>{
-                ...?namedArgs,
-                #action: action is Result ? action.value : action
-              }
-            : namedArgs,
+        namedArgs: <Symbol, dynamic>{
+          ...?namedArgs,
+          #action: action is Result ? action.value : action
+        },
         Catch: Catch,
         Finally: Finally,
         name: name,

--- a/lib/src/effects/takeLeading.dart
+++ b/lib/src/effects/takeLeading.dart
@@ -37,7 +37,7 @@ part of redux_saga;
 ///
 ///  //...
 ///
-///  fetchUser(action) sync* {
+///  fetchUser({dynamic action}) sync* {
 ///    // ...
 ///  }
 ///
@@ -89,12 +89,10 @@ Iterable<Effect> _TakeLeading(Function saga,
 
     yield Call(saga,
         args: args,
-        namedArgs: _functionHasActionArgument(saga)
-            ? <Symbol, dynamic>{
-                ...?namedArgs,
-                #action: action is Result ? action.value : action
-              }
-            : namedArgs,
+        namedArgs: <Symbol, dynamic>{
+          ...?namedArgs,
+          #action: action is Result ? action.value : action
+        },
         Catch: Catch,
         Finally: Finally);
   }

--- a/lib/src/effects/throttle.dart
+++ b/lib/src/effects/throttle.dart
@@ -112,12 +112,10 @@ Iterable<Effect> _Throttle(Function saga,
 
     yield Fork(saga,
         args: args,
-        namedArgs: _functionHasActionArgument(saga)
-            ? <Symbol, dynamic>{
-                ...?namedArgs,
-                #action: action is Result ? action.value : action
-              }
-            : namedArgs,
+        namedArgs: <Symbol, dynamic>{
+          ...?namedArgs,
+          #action: action is Result ? action.value : action
+        },
         Catch: Catch,
         Finally: Finally,
         name: name);

--- a/lib/src/effects/try.dart
+++ b/lib/src/effects/try.dart
@@ -23,7 +23,7 @@ part of redux_saga;
 ///      yield Select(selector: getCart, result: cart);
 ///      yield Call(buyProductsAPI, args: [cart.value]);
 ///      yield Put(CheckoutSuccess(cart.value));
-///    }, Catch: (error) sync* {
+///    }, Catch: (e, s) sync* {
 ///      yield Put(CheckoutFailure(error));
 ///    });
 ///  }

--- a/lib/src/effects/tryReturn.dart
+++ b/lib/src/effects/tryReturn.dart
@@ -12,7 +12,7 @@ part of redux_saga;
 ///    yield TryReturn(() sync* { //returns saga
 ///      //...
 ///      yield Return(somevalue1); //returns Try
-///    }, Catch: (error) sync* {
+///    }, Catch: (e, s) sync* {
 ///      //...
 ///      yield Return(somevalue2); //returns Try
 ///    });
@@ -27,7 +27,7 @@ part of redux_saga;
 ///    yield Try(() sync* {
 ///      //...
 ///      yield Return(somevalue1); //returns Try. Does not return saga
-///    }, Catch: (error) sync* {
+///    }, Catch: (e, s) sync* {
 ///      //...
 ///      yield Return(somevalue2); //returns Try. Does not return saga
 ///    }, result: result);
@@ -51,7 +51,7 @@ part of redux_saga;
 ///      yield Select(selector: getCart, result: cart);
 ///      yield Call(buyProductsAPI, args: [cart.value]);
 ///      yield Return(CheckoutSuccess(cart.value));
-///    }, Catch: (error) sync* {
+///    }, Catch: (e, s) sync* {
 ///      yield Return(CheckoutFailure(error));
 ///    });
 ///  }

--- a/lib/src/functions.dart
+++ b/lib/src/functions.dart
@@ -1,22 +1,5 @@
 part of redux_saga;
 
-///Returns true for the following closures
-///() => void
-///() => Null
-bool _isFunctionVoid(Function f) {
-  if (f == null) throw CannotDetermineNullFunctionReturnType();
-  var closure = f.toString();
-  return closure.contains(') => void') ||
-      closure.contains(') => Null') ||
-      closure.contains(') => Future<void>') ||
-      closure.contains(') => Future<Null>');
-}
-
-bool _functionHasActionArgument(Function f) {
-  var closure = f.toString();
-  return closure.contains(' action}') || closure.contains(' action,');
-}
-
 dynamic _callFunctionWithArgument(Function f, List<dynamic> args,
     Map<Symbol, dynamic> namedArgs, dynamic firstArg) {
   return Function.apply(f, <dynamic>[firstArg, ...?args], namedArgs);
@@ -31,18 +14,6 @@ dynamic _callFinallyFunction(Function f) {
   return Function.apply(f, null);
 }
 
-///possible closures :
-///(Exception) => void
-///(Exception, StackTrace) => void
 dynamic _callErrorFunction(Function f, _SagaInternalException error) {
-//  _checkFunction(f);
-  var closure = f.toString();
-  final args = <dynamic>[];
-  if (closure.contains('(dynamic)')) {
-    args.add(error.message);
-  } else if (closure.contains('(dynamic, StackTrace)')) {
-    args.add(error.message);
-    args.add(error.stackTrace);
-  }
-  return Function.apply(f, args, null);
+  return Function.apply(f, <dynamic>[error.message, error.stackTrace], null);
 }

--- a/lib/src/taskRunner.dart
+++ b/lib/src/taskRunner.dart
@@ -131,8 +131,7 @@ class _taskRunner {
       clearCurrentExecution(ncb);
       onErrorExecuted = true;
       codeBlock = _CodeBlock.errorCode;
-      processFunctionReturn(ncb, _callErrorFunction(onError, currentException),
-          !_isFunctionVoid(onError));
+      processFunctionReturn(ncb, _callErrorFunction(onError, currentException));
     } catch (e, s) {
       ncb.next(arg: _createSagaException(e, s), isErr: true);
     }
@@ -143,21 +142,16 @@ class _taskRunner {
       clearCurrentExecution(callback);
       onFinallyExecuted = true;
       codeBlock = _CodeBlock.finallyCode;
-      processFunctionReturn(callback, _callFinallyFunction(onFinally),
-          !_isFunctionVoid(onFinally));
+      processFunctionReturn(callback, _callFinallyFunction(onFinally));
     } catch (e, s) {
       callback.next(arg: _createSagaException(e, s), isErr: true);
     }
   }
 
-  void processFunctionReturn(
-      _TaskCallback callback, dynamic fr, bool assignTaskResult) {
+  void processFunctionReturn(_TaskCallback callback, dynamic fr) {
     if (fr is Future || fr is FutureWithCancel) {
       var tcb =
           _TaskCallback(({_TaskCallback invoker, dynamic arg, bool isErr}) {
-        if (!isErr) {
-          if (assignTaskResult) mainTask.task.taskResult = arg;
-        }
         callback.next(arg: arg, isErr: isErr);
       }, () {
         callback.cancel();
@@ -173,7 +167,6 @@ class _taskRunner {
       iterator = fr.iterator;
       callback.next();
     } else {
-      if (assignTaskResult) mainTask.task.taskResult = fr;
       callback.next(arg: fr);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: redux_saga
 maintainer: Bilal Uslu (@bilaluslu)
 description: redux_saga is a library that aims to make application side effects easier to manage, more efficient to execute, easy to test, and better at handling failures.
 homepage: https://github.com/reduxsaga/redux_saga
-version: 1.1.16
+version: 2.0.0
 repository: https://github.com/reduxsaga/redux_saga
 
 environment:

--- a/test/actionChannel_test.dart
+++ b/test/actionChannel_test.dart
@@ -55,7 +55,10 @@ void main() {
       expect(task.toFuture(), completion(TypeMatcher<Channel>()));
 
       //saga must queue dispatched actions
-      expect(task.toFuture().then((dynamic value) => buffer.flush().map((e) => e.payload)),
+      expect(
+          task
+              .toFuture()
+              .then((dynamic value) => buffer.flush().map((e) => e.payload)),
           completion([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
     });
 
@@ -94,7 +97,14 @@ void main() {
                   task.isAborted,
                   values
                 ]),
-            completion([null, null, false, false, false, Iterable<int>.generate(10).toList()]));
+            completion([
+              null,
+              null,
+              false,
+              false,
+              false,
+              Iterable<int>.generate(10).toList()
+            ]));
 
         async.elapse(Duration(milliseconds: 500));
       });
@@ -136,7 +146,14 @@ void main() {
                   task.isAborted,
                   values
                 ]),
-            completion([null, null, false, false, false, Iterable<int>.generate(10).toList()]));
+            completion([
+              null,
+              null,
+              false,
+              false,
+              false,
+              Iterable<int>.generate(10).toList()
+            ]));
 
         async.elapse(Duration(milliseconds: 500));
       });

--- a/test/all_test.dart
+++ b/test/all_test.dart
@@ -56,7 +56,8 @@ void main() {
       });
 
       // saga must fulfill parallel effects
-      expect(task.toFuture().then((dynamic value) => all.value), completion(<Symbol, dynamic>{}));
+      expect(task.toFuture().then((dynamic value) => all.value),
+          completion(<Symbol, dynamic>{}));
     });
 
     test('saga parallel effect: handling errors', () {
@@ -80,14 +81,15 @@ void main() {
           #call1: Call(() => comps[0].future),
           #call2: Call(() => comps[1].future),
         }, result: all);
-      }, Catch: (dynamic e) {
+      }, Catch: (dynamic e, StackTrace s) {
         caught = e;
       });
 
       //saga must catch the first error in parallel effects
       expect(task.toFuture().then<dynamic>((dynamic value) => caught),
           completion(exceptionToBeCaught));
-      expect(task.toFuture().then((dynamic value) => all.value), completion(null));
+      expect(
+          task.toFuture().then((dynamic value) => all.value), completion(null));
     });
 
     test('saga parallel effect: handling END', () {
@@ -110,11 +112,14 @@ void main() {
         onfinally = true;
       });
 
-      ResolveSequentially([callF(() => comp.complete(1)), callF(() => store.dispatch(End))]);
+      ResolveSequentially(
+          [callF(() => comp.complete(1)), callF(() => store.dispatch(End))]);
 
       //saga must end Parallel Effect if one of the effects resolve with END
-      expect(task.toFuture().then((dynamic value) => onfinally), completion(true));
-      expect(task.toFuture().then((dynamic value) => all.value), completion(null));
+      expect(
+          task.toFuture().then((dynamic value) => onfinally), completion(true));
+      expect(
+          task.toFuture().then((dynamic value) => all.value), completion(null));
     });
 
     test('all test', () {

--- a/test/base_test.dart
+++ b/test/base_test.dart
@@ -47,7 +47,8 @@ void main() {
     test('saga error handling', () {
       dynamic error;
 
-      var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createMiddleware(options: Options(onError: (dynamic e, String s) {
         error = e;
       }));
       var store = createStore(sagaMiddleware);
@@ -71,7 +72,8 @@ void main() {
       expect(task1.toFuture().catchError((dynamic e) => <dynamic>[e, error]),
           completion([exceptionToBeCaught, exceptionToBeCaught]));
 
-      expect(task1.toFuture().catchError((dynamic e) => e), completion(exceptionToBeCaught));
+      expect(task1.toFuture().catchError((dynamic e) => e),
+          completion(exceptionToBeCaught));
 
       //try + catch + finally
       var actual = <dynamic>[];
@@ -121,7 +123,8 @@ void main() {
       }, args: <dynamic>['arg']);
 
       //saga must handle generator output
-      expect(task.toFuture().then((dynamic value) => actual), completion(['arg', 2]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(['arg', 2]));
     });
   });
 }

--- a/test/call_test.dart
+++ b/test/call_test.dart
@@ -44,10 +44,13 @@ void main() {
       });
 
       //saga must fulfill declarative call effects
-      expect(task.toFuture().then((dynamic value) => actual), completion([1, 2, 3, #four]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([1, 2, 3, #four]));
     });
 
-    test('saga handles call effects and throw the rejected values inside the generator', () {
+    test(
+        'saga handles call effects and throw the rejected values inside the generator',
+        () {
       var actual = <dynamic>[];
 
       Future<dynamic> fail(dynamic msg) {
@@ -73,15 +76,18 @@ void main() {
         yield Put(_Action('start'));
         yield Call(fail, args: <dynamic>['failure']);
         yield Put(_Action('success'));
-      }, Catch: (dynamic e) sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         yield Put(_Action(e));
       });
 
       //saga dispatches appropriate actions
-      expect(task.toFuture().then((dynamic value) => actual), completion(['start', 'failure']));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(['start', 'failure']));
     });
 
-    test('saga handles call\'s synchronous failures and throws in the calling generator (1)', () {
+    test(
+        'saga handles call\'s synchronous failures and throws in the calling generator (1)',
+        () {
       var actual = <dynamic>[];
 
       void failfn() {
@@ -110,20 +116,28 @@ void main() {
           yield Put(_Action('start child'));
           yield Call(failfn);
           yield Put(_Action('success child'));
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           yield Put(_Action('failure child'));
         });
         yield Put(_Action('success parent'));
-      }, Catch: (dynamic e) sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         yield Put(_Action('failure parent'));
       });
 
       //saga dispatches appropriate actions
-      expect(task.toFuture().then((dynamic value) => actual),
-          completion(['start parent', 'start child', 'failure child', 'success parent']));
+      expect(
+          task.toFuture().then((dynamic value) => actual),
+          completion([
+            'start parent',
+            'start child',
+            'failure child',
+            'success parent'
+          ]));
     });
 
-    test('saga handles call\'s synchronous failures and throws in the calling generator (2)', () {
+    test(
+        'saga handles call\'s synchronous failures and throws in the calling generator (2)',
+        () {
       var actual = <dynamic>[];
 
       void failfn() {
@@ -152,21 +166,29 @@ void main() {
           yield Put(_Action('start child'));
           yield Call(failfn);
           yield Put(_Action('success child'));
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           yield Put(_Action('failure child'));
           throw e;
         });
         yield Put(_Action('success parent'));
-      }, Catch: (dynamic e) sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         yield Put(_Action('failure parent'));
       });
 
       //saga dispatches appropriate actions
-      expect(task.toFuture().then((dynamic value) => actual),
-          completion(['start parent', 'start child', 'failure child', 'failure parent']));
+      expect(
+          task.toFuture().then((dynamic value) => actual),
+          completion([
+            'start parent',
+            'start child',
+            'failure child',
+            'failure parent'
+          ]));
     });
 
-    test('saga handles call\'s synchronous failures and throws in the calling generator (3)', () {
+    test(
+        'saga handles call\'s synchronous failures and throws in the calling generator (3)',
+        () {
       var actual = <dynamic>[];
 
       Iterable<Effect> failGen() sync* {
@@ -193,7 +215,7 @@ void main() {
         //call child generator
         yield Call(failGen);
         yield Put(_Action('success parent'));
-      }, Catch: (dynamic e) sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         yield Put(_Action(e));
         yield Put(_Action('failure parent'));
       });
@@ -223,7 +245,7 @@ void main() {
 
         yield Return(result.value);
         execution.add(3);
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(4);
       }, Finally: () {
         execution.add(5);
@@ -591,9 +613,9 @@ void main() {
         yield Call(() sync* {
           execution.add(1);
           yield Return(value1);
-        }, Finally: () {
+        }, Finally: () sync* {
           execution.add(2);
-          return value2;
+          yield Return(value2);
         }, result: result);
 
         execution.add(3);
@@ -676,9 +698,9 @@ void main() {
         yield Call(() sync* {
           execution.add(1);
           yield Return(value1);
-        }, Finally: () async {
+        }, Finally: () sync* {
           execution.add(2);
-          return value2;
+          yield Return(value2);
         }, result: result);
 
         execution.add(3);
@@ -848,7 +870,7 @@ void main() {
         yield Call(() sync* {
           execution.add(1);
           yield Return(value1);
-        }, Catch: () sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           execution.add(2);
         }, Finally: () sync* {
           execution.add(3);
@@ -892,7 +914,7 @@ void main() {
         yield Call(() sync* {
           execution.add(1);
           throw exceptionToBeCaught;
-        }, Catch: () sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           execution.add(2);
         }, Finally: () sync* {
           execution.add(3);
@@ -936,7 +958,7 @@ void main() {
         yield Call(() {
           execution.add(1);
           throw exceptionToBeCaught;
-        }, Catch: () {
+        }, Catch: (dynamic e, StackTrace s) {
           execution.add(2);
         }, Finally: () {
           execution.add(3);
@@ -980,7 +1002,7 @@ void main() {
         yield Call(() async {
           execution.add(1);
           throw exceptionToBeCaught;
-        }, Catch: () async {
+        }, Catch: (dynamic e, StackTrace s) async {
           execution.add(2);
         }, Finally: () async {
           execution.add(3);
@@ -1024,7 +1046,7 @@ void main() {
         yield Call(() sync* {
           execution.add(1);
           throw exceptionToBeCaught;
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           caught = e;
           execution.add(2);
         }, Finally: () sync* {
@@ -1224,7 +1246,7 @@ void main() {
           execution.add(1);
           yield Cancel();
           yield Return(value1);
-        }, Catch: () async {
+        }, Catch: (dynamic e, StackTrace s) async {
           execution.add(2);
         }, Finally: () async {
           execution.add(3);
@@ -1267,7 +1289,7 @@ void main() {
         yield Call(() sync* {
           execution.add(1);
           yield Return(value1);
-        }, Catch: () sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           execution.add(2);
         }, Finally: () sync* {
           execution.add(3);

--- a/test/cancellation_test.dart
+++ b/test/cancellation_test.dart
@@ -70,8 +70,15 @@ void main() {
       expect(task.toFuture(), completion(TaskCancel));
 
       //cancelled call effect must throw exception inside called subroutine
-      expect(task.toFuture().then((dynamic value) => actual),
-          completion(['start', 'subroutine start', 'cancel', 'subroutine cancelled', 'cancelled']));
+      expect(
+          task.toFuture().then((dynamic value) => actual),
+          completion([
+            'start',
+            'subroutine start',
+            'cancel',
+            'subroutine cancelled',
+            'cancelled'
+          ]));
     });
 
     test('saga cancellation: forked children', () {
@@ -363,7 +370,8 @@ void main() {
           ]));
     });
 
-    test('saga cancellation: join effect (join from the same task\'s parent)', () {
+    test('saga cancellation: join effect (join from the same task\'s parent)',
+        () {
       var actual = <dynamic>[];
 
       var startComp = Completer<String>();
@@ -435,8 +443,15 @@ void main() {
       //since cancellation is noop on an already terminated task the deadlock wont happen
 
       //cancelled routine must cancel proper joiners
-      expect(task.toFuture().then((dynamic value) => actual),
-          completion(['start', 'subroutine start', 'cancel', 'cancelled', 'subroutine cancelled']));
+      expect(
+          task.toFuture().then((dynamic value) => actual),
+          completion([
+            'start',
+            'subroutine start',
+            'cancel',
+            'cancelled',
+            'subroutine cancelled'
+          ]));
     });
 
     test('saga cancellation: parallel effect', () {
@@ -492,8 +507,10 @@ void main() {
 
         yield Try(() sync* {
           var all = AllResult();
-          yield All(<dynamic, Effect>{#call1: Call(subroutine1), #call2: Call(subroutine2)},
-              result: all);
+          yield All(<dynamic, Effect>{
+            #call1: Call(subroutine1),
+            #call2: Call(subroutine2)
+          }, result: all);
           actual.add(all.value);
         }, Finally: () sync* {
           var cancelled = Result<bool>();
@@ -584,9 +601,10 @@ void main() {
 
         yield Try(() sync* {
           var race = RaceResult();
-          yield Race(
-              <dynamic, Effect>{#subroutine1: Call(subroutine1), #subroutine2: Call(subroutine2)},
-              result: race);
+          yield Race(<dynamic, Effect>{
+            #subroutine1: Call(subroutine1),
+            #subroutine2: Call(subroutine2)
+          }, result: race);
           actual.add(race.value);
         }, Finally: () sync* {
           var cancelled = Result<bool>();
@@ -665,9 +683,12 @@ void main() {
 
       Iterable<Effect> main() sync* {
         yield Try(() sync* {
-          yield All(<dynamic, Effect>{#call1: Call(subtask1), #call2: Call(subtask2)});
-        }, Catch: (dynamic error) sync* {
-          actual.add('caught $error');
+          yield All(<dynamic, Effect>{
+            #call1: Call(subtask1),
+            #call2: Call(subtask2)
+          });
+        }, Catch: (dynamic e, StackTrace s) sync* {
+          actual.add('caught $e');
         });
       }
 
@@ -682,8 +703,12 @@ void main() {
       //saga must cancel parallel sub-effects on rejection
       expect(
           task.toFuture().then((dynamic value) => actual),
-          completion(
-              ['subtask_1', 'subtask_2', 'subtask 2 cancelled', 'caught subtask_1 rejection']));
+          completion([
+            'subtask_1',
+            'subtask_2',
+            'subtask 2 cancelled',
+            'caught subtask_1 rejection'
+          ]));
     });
 
     test('saga cancellation: automatic race competitor cancellation', () {
@@ -755,7 +780,10 @@ void main() {
 
       Iterable<Effect> main() sync* {
         yield All(<dynamic, Effect>{
-          #race: Race(<dynamic, Effect>{#winner: Call(winnerSubtask), #loser: Call(loserSubtask)}),
+          #race: Race(<dynamic, Effect>{
+            #winner: Call(winnerSubtask),
+            #loser: Call(loserSubtask)
+          }),
           #parallelSubtask: Call(parallelSubtask)
         });
       }
@@ -835,8 +863,10 @@ void main() {
       expect(task.toFuture(), completion(null));
 
       //saga must cancel forked tasks
-      expect(task.toFuture().then((dynamic value) => actual),
-          completion(['signIn', 'expire_1', 'expire_2', 'signOut', 'task cancelled']));
+      expect(
+          task.toFuture().then((dynamic value) => actual),
+          completion(
+              ['signIn', 'expire_1', 'expire_2', 'signOut', 'task cancelled']));
     });
 
     test('saga cancellation: nested task cancellation', () {
@@ -899,7 +929,10 @@ void main() {
           yield Call(() => subtaskComps[0].future, result: result);
           actual.add(result.value);
 
-          yield All(<dynamic, Effect>{#call1: Call(nestedTask1), #call2: Call(nestedTask2)});
+          yield All(<dynamic, Effect>{
+            #call1: Call(nestedTask1),
+            #call2: Call(nestedTask2)
+          });
 
           yield Call(() => subtaskComps[1].future, result: result);
           actual.add(result.value);
@@ -1076,7 +1109,8 @@ void main() {
       expect(task.toFuture(), completion(null));
 
       //it must be possible to cancel multiple tasks at once
-      expect(task.toFuture().then((dynamic value) => actual), completion([0, 1, 2]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([0, 1, 2]));
     });
 
     test('cancel should support for self cancellation', () {
@@ -1107,7 +1141,8 @@ void main() {
       expect(task.toFuture(), completion(null));
 
       //it must be possible to cancel multiple tasks at once
-      expect(task.toFuture().then((dynamic value) => actual), completion(['self cancellation']));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(['self cancellation']));
     });
 
     test('should bubble an exception thrown during cancellation', () {
@@ -1128,7 +1163,8 @@ void main() {
         }
 
         dynamic caughtMiddlewareError;
-        var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+        var sagaMiddleware =
+            createMiddleware(options: Options(onError: (dynamic e, String s) {
           caughtMiddlewareError = e;
         }));
         var store = createStore(sagaMiddleware);
@@ -1137,7 +1173,8 @@ void main() {
         var task = sagaMiddleware.run(main);
 
         expect(task.toFuture(), throwsA(exceptionToBeCaught));
-        expect(task.toFuture().catchError((dynamic e) => e), completion(exceptionToBeCaught));
+        expect(task.toFuture().catchError((dynamic e) => e),
+            completion(exceptionToBeCaught));
         expect(task.toFuture().catchError((dynamic e) => caughtMiddlewareError),
             completion(exceptionToBeCaught));
 
@@ -1165,9 +1202,8 @@ void main() {
         var task = sagaMiddleware.run(main);
 
         expect(
-            task
-                .toFuture()
-                .then((dynamic value) => [task.isCancelled, task.isRunning, task.isAborted]),
+            task.toFuture().then((dynamic value) =>
+                [task.isCancelled, task.isRunning, task.isAborted]),
             completion([true, false, false]));
 
         async.elapse(Duration(milliseconds: 500));

--- a/test/channelRecipes_test.dart
+++ b/test/channelRecipes_test.dart
@@ -36,7 +36,8 @@ void main() {
       store.dispatch(End);
 
       // Sagas must take consecutive actions dispatched synchronously on an action channel even if it performs blocking calls
-      expect(task.toFuture().then((dynamic value) => actual), completion([0, 1, 2]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([0, 1, 2]));
     });
 
     test('error check when constructing actionChannels', () {

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -34,11 +34,13 @@ void main() {
       expect(actual, equals([End, End]));
 
       actual.clear();
-      chan.take(TakeCallback<dynamic>(logger)); // closed channel must resolve new takers with END
+      chan.take(TakeCallback<dynamic>(
+          logger)); // closed channel must resolve new takers with END
 
       expect(actual, equals([End]));
 
-      chan.put('action-after-end'); // channel must reject messages after being closed
+      chan.put(
+          'action-after-end'); // channel must reject messages after being closed
 
       expect(actual, equals([End]));
     });
@@ -66,7 +68,8 @@ void main() {
       // channel must queue pending takers if there are no buffered messages
       chan.take(t1);
 
-      expect([called['t1'], log, spyBuffer.buffer], equals([false, <dynamic>[], <dynamic>[]]));
+      expect([called['t1'], log, spyBuffer.buffer],
+          equals([false, <dynamic>[], <dynamic>[]]));
 
       final t2 = taker('t2');
       chan.take(t2);
@@ -95,7 +98,8 @@ void main() {
           ]));
 
       final t3 = taker('t3');
-      chan.take(t3); // channel must resolve new takers if there are buffered messages
+      chan.take(
+          t3); // channel must resolve new takers if there are buffered messages
 
       expect(
           [called['t3'], spyBuffer.buffer, log],
@@ -109,11 +113,13 @@ void main() {
 
       chan.close();
       chan.put('hi');
-      chan.put('I said hi'); // putting on an already closed channel should be noop
+      chan.put(
+          'I said hi'); // putting on an already closed channel should be noop
 
       expect(spyBuffer.buffer, equals([4]));
 
-      chan.take(taker('t4')); // closed channel must resolve new takers with any buffered message
+      chan.take(taker(
+          't4')); // closed channel must resolve new takers with any buffered message
 
       expect(
           [log, spyBuffer.buffer],
@@ -148,7 +154,8 @@ void main() {
           buffer: Buffers.expanding<dynamic>(10));
 
       final actual = <dynamic>[];
-      chan.take(TakeCallback<dynamic>((dynamic message) => actual.add(message)));
+      chan.take(
+          TakeCallback<dynamic>((dynamic message) => actual.add(message)));
       _emitter('action-1'); // eventChannel must notify takers on a new action
 
       expect(actual, equals(['action-1']));
@@ -158,19 +165,22 @@ void main() {
       expect(actual, equals(['action-1']));
 
       // eventChannel must notify takers if messages are buffered
-      chan.take(TakeCallback<dynamic>((dynamic message) => actual.add(message)));
+      chan.take(
+          TakeCallback<dynamic>((dynamic message) => actual.add(message)));
 
       expect(actual, equals(['action-1', 'action-1']));
 
       actual.clear();
-      chan.take(TakeCallback<dynamic>((dynamic message) => actual.add(message)));
+      chan.take(
+          TakeCallback<dynamic>((dynamic message) => actual.add(message)));
       chan.close(); // eventChannel must notify all pending takers on END
 
       expect(actual, equals([End]));
 
       actual.clear();
       // eventChannel must notify all new takers if closed
-      chan.take(TakeCallback<dynamic>((dynamic message) => actual.add(message)));
+      chan.take(
+          TakeCallback<dynamic>((dynamic message) => actual.add(message)));
 
       expect(actual, equals([End]));
     });
@@ -202,7 +212,8 @@ void main() {
 
       // should emit END event
       expect(messageCompleter.future, completion(End));
-      expect(messageCompleter.future.then((dynamic value) => unsubscribed), completion(true));
+      expect(messageCompleter.future.then((dynamic value) => unsubscribed),
+          completion(true));
     });
 
     test('Expanding buffer', () {

--- a/test/cloneableGenerator_test.dart
+++ b/test/cloneableGenerator_test.dart
@@ -36,7 +36,7 @@ void main() {
         values.add(gen2.current);
       }
 
-      expect(values,<int>[0, 1, 2, 3, 4, 3, 4, 4]);
+      expect(values, <int>[0, 1, 2, 3, 4, 3, 4, 4]);
     });
   });
 }

--- a/test/context_test.dart
+++ b/test/context_test.dart
@@ -8,7 +8,8 @@ void main() {
     test('saga must handle context in dynamic scoping manner', () {
       var actual = <dynamic>[];
 
-      var sagaMiddleware = createMiddleware(options: Options(context: <dynamic, dynamic>{#a: 1}));
+      var sagaMiddleware = createMiddleware(
+          options: Options(context: <dynamic, dynamic>{#a: 1}));
       var store = createStore(sagaMiddleware);
       sagaMiddleware.setStore(store);
 
@@ -35,7 +36,8 @@ void main() {
       });
 
       //saga must handle context in dynamic scoping manner
-      expect(task.toFuture().then((dynamic value) => actual), completion([1, 1, 2, 3, null]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([1, 1, 2, 3, null]));
     });
   });
 }

--- a/test/cps_test.dart
+++ b/test/cps_test.dart
@@ -21,13 +21,14 @@ void main() {
             cb.callback(err: 'err');
           });
           actual.add('call 2');
-        }, Catch: (dynamic error) sync* {
-          actual.add('call $error');
+        }, Catch: (dynamic e, StackTrace s) sync* {
+          actual.add('call $e');
         });
       });
 
       //saga must fulfill cps call effects
-      expect(task.toFuture().then((dynamic value) => actual), completion(['call 1', 'call err']));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(['call 1', 'call err']));
     });
 
     test('saga synchronous cps failures handling', () {
@@ -55,7 +56,7 @@ void main() {
             throw Exception('child error');
           });
           yield Put(TestActionC('success child'));
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           yield Put(TestActionC('failure child'));
         });
       }
@@ -65,7 +66,7 @@ void main() {
           yield Put(TestActionC('start parent'));
           yield Call(genFnChild);
           yield Put(TestActionC('success parent'));
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           yield Put(TestActionC('failure parent'));
         });
       }
@@ -73,8 +74,14 @@ void main() {
       var task = sagaMiddleware.run(genFnParent);
 
       //saga should inject call error into generator
-      expect(task.toFuture().then((dynamic value) => actual),
-          completion(['start parent', 'startChild', 'failure child', 'success parent']));
+      expect(
+          task.toFuture().then((dynamic value) => actual),
+          completion([
+            'start parent',
+            'startChild',
+            'failure child',
+            'success parent'
+          ]));
     });
 
     test('saga cps cancellation handling', () {
@@ -100,7 +107,8 @@ void main() {
       });
 
       //saga should call cancellation function on callback
-      expect(task.toFuture().then((dynamic value) => cancelled), completion(true));
+      expect(
+          task.toFuture().then((dynamic value) => cancelled), completion(true));
     });
 
     test('cps test', () {

--- a/test/debounce_test.dart
+++ b/test/debounce_test.dart
@@ -24,7 +24,10 @@ void main() {
           yield Debounce(({dynamic action}) sync* {
             called++;
             actual.add(<dynamic>[called, action.payload]);
-          }, duration: Duration(milliseconds: delayMs), pattern: TestActionC, result: forkedTask);
+          },
+              duration: Duration(milliseconds: delayMs),
+              pattern: TestActionC,
+              result: forkedTask);
           yield Take(pattern: TestActionCancel);
           yield Cancel([forkedTask.value]);
         });
@@ -70,7 +73,10 @@ void main() {
           yield Debounce(({dynamic action}) sync* {
             called++;
             actual.add(<dynamic>[called, action.payload]);
-          }, duration: Duration(milliseconds: delayMs), pattern: TestActionC, result: forkedTask);
+          },
+              duration: Duration(milliseconds: delayMs),
+              pattern: TestActionC,
+              result: forkedTask);
           yield Take(pattern: TestActionCancel);
           yield Cancel([forkedTask.value]);
         });
@@ -120,7 +126,10 @@ void main() {
           yield Debounce(({dynamic action}) sync* {
             called++;
             actual.add(<dynamic>[called, action.payload]);
-          }, duration: Duration(milliseconds: delayMs), pattern: TestActionC, result: forkedTask);
+          },
+              duration: Duration(milliseconds: delayMs),
+              pattern: TestActionC,
+              result: forkedTask);
           yield Take(pattern: TestActionCancel);
           yield Cancel([forkedTask.value]);
         });
@@ -158,7 +167,10 @@ void main() {
           yield Debounce(({dynamic action}) sync* {
             called++;
             actual.add(<dynamic>[called, action]);
-          }, duration: Duration(milliseconds: delayMs), channel: customChannel, result: forkedTask);
+          },
+              duration: Duration(milliseconds: delayMs),
+              channel: customChannel,
+              result: forkedTask);
           yield Take(pattern: TestActionCancel);
           yield Cancel([forkedTask.value]);
         });
@@ -202,7 +214,10 @@ void main() {
         sagaMiddleware.run(() sync* {
           yield Debounce(({dynamic action}) sync* {
             called++;
-          }, duration: Duration(milliseconds: delayMs), channel: customChannel, result: forkedTask);
+          },
+              duration: Duration(milliseconds: delayMs),
+              channel: customChannel,
+              result: forkedTask);
         });
 
         var f = ResolveSequentially([
@@ -212,7 +227,8 @@ void main() {
 
         expect(
             f.then((dynamic value) => <dynamic>[
-                  forkedTask.value.isRunning, // should finish debounce task on END
+                  forkedTask
+                      .value.isRunning, // should finish debounce task on END
                   called // should not call function if finished with END
                 ]),
             completion([false, 0]));
@@ -237,7 +253,10 @@ void main() {
         sagaMiddleware.run(() sync* {
           yield Debounce(({dynamic action}) sync* {
             called++;
-          }, duration: Duration(milliseconds: delayMs), pattern: TestActionC, result: forkedTask);
+          },
+              duration: Duration(milliseconds: delayMs),
+              pattern: TestActionC,
+              result: forkedTask);
         });
 
         var f = ResolveSequentially([
@@ -247,7 +266,8 @@ void main() {
 
         expect(
             f.then((dynamic value) => <dynamic>[
-                  forkedTask.value.isRunning, // should finish debounce task on END
+                  forkedTask
+                      .value.isRunning, // should finish debounce task on END
                   called // should not call function if finished with END
                 ]),
             completion([false, 0]));
@@ -272,7 +292,10 @@ void main() {
         sagaMiddleware.run(() sync* {
           yield Debounce(({dynamic action}) sync* {
             called++;
-          }, duration: Duration(milliseconds: delayMs), pattern: TestActionC, result: forkedTask);
+          },
+              duration: Duration(milliseconds: delayMs),
+              pattern: TestActionC,
+              result: forkedTask);
         });
 
         var f = ResolveSequentially([
@@ -284,7 +307,8 @@ void main() {
 
         expect(
             f.then((dynamic value) => <dynamic>[
-                  forkedTask.value.isRunning, // should finish debounce task on END
+                  forkedTask
+                      .value.isRunning, // should finish debounce task on END
                   called // should interrupt race on END
                 ]),
             completion([false, 0]));

--- a/test/effectMiddlewares_test.dart
+++ b/test/effectMiddlewares_test.dart
@@ -32,14 +32,15 @@ void main() {
         yield Return(result);
       }
 
-      var sagaMiddleware =
-          createMiddleware(options: Options(effectMiddlewares: [effectMiddleware]));
+      var sagaMiddleware = createMiddleware(
+          options: Options(effectMiddlewares: [effectMiddleware]));
       var store = createStore(sagaMiddleware);
       sagaMiddleware.setStore(store);
 
       var task = sagaMiddleware.run(() sync* {
         var all = AllResult();
-        yield All(<dynamic, Effect>{#call: Call(fnA), #apiCall: apiCall}, result: all);
+        yield All(<dynamic, Effect>{#call: Call(fnA), #apiCall: apiCall},
+            result: all);
         actual.add(all.value);
       });
 
@@ -99,7 +100,8 @@ void main() {
       var callA = Call(fnA, result: Result<dynamic>());
 
       var sagaMiddleware = createMiddleware(
-          options: Options(effectMiddlewares: [effectMiddleware1, effectMiddleware2]));
+          options: Options(
+              effectMiddlewares: [effectMiddleware1, effectMiddleware2]));
       var store = createStore(sagaMiddleware);
       sagaMiddleware.setStore(store);
 
@@ -183,8 +185,8 @@ void main() {
         yield Return('result');
       }
 
-      var sagaMiddleware =
-          createMiddleware(options: Options(effectMiddlewares: [effectMiddleware]));
+      var sagaMiddleware = createMiddleware(
+          options: Options(effectMiddlewares: [effectMiddleware]));
       var store = createStore(sagaMiddleware);
       sagaMiddleware.setStore(store);
 

--- a/test/fork_test.dart
+++ b/test/fork_test.dart
@@ -6,7 +6,8 @@ import 'helpers/store.dart';
 
 void main() {
   group('fork test', () {
-    test('should not interpret returned effect. fork(() => effectCreator())', () {
+    test('should not interpret returned effect. fork(() => effectCreator())',
+        () {
       var sagaMiddleware = createMiddleware();
       var store = createStore(sagaMiddleware);
       sagaMiddleware.setStore(store);
@@ -26,7 +27,9 @@ void main() {
       expect(task.toFuture(), completion(call));
     });
 
-    test('should not interpret returned effect. yield fork(takeEvery, \'pattern\', fn)', () {
+    test(
+        'should not interpret returned effect. yield fork(takeEvery, \'pattern\', fn)',
+        () {
       var sagaMiddleware = createMiddleware();
       var store = createStore(sagaMiddleware);
       sagaMiddleware.setStore(store);
@@ -60,7 +63,9 @@ void main() {
       expect(task.toFuture(), completion('a'));
     });
 
-    test('should handle future that resolves undefined properly. fork(() => Future(()=>null))', () {
+    test(
+        'should handle future that resolves undefined properly. fork(() => Future(()=>null))',
+        () {
       var sagaMiddleware = createMiddleware();
       var store = createStore(sagaMiddleware);
       sagaMiddleware.setStore(store);
@@ -829,7 +834,8 @@ void main() {
 
           execution.add(2);
 
-          yield Join(<dynamic, Task>{#forkA: forkedTaskA.value}, result: joinResult);
+          yield Join(<dynamic, Task>{#forkA: forkedTaskA.value},
+              result: joinResult);
 
           for (var i = 0; i < 10; i++) {
             values.write(i);
@@ -953,8 +959,10 @@ void main() {
 
           execution.add(2);
 
-          yield Join(<dynamic, Task>{#forkA: forkedTaskA.value, #forkB: forkedTaskB.value},
-              result: joinResult);
+          yield Join(<dynamic, Task>{
+            #forkA: forkedTaskA.value,
+            #forkB: forkedTaskB.value
+          }, result: joinResult);
 
           for (var i = 0; i < 10; i++) {
             values.write(i);
@@ -1083,8 +1091,10 @@ void main() {
 
           execution.add(4);
 
-          yield Join(<dynamic, Task>{#forkA: forkedTaskA.value, #forkB: forkedTaskB.value},
-              result: joinResult);
+          yield Join(<dynamic, Task>{
+            #forkA: forkedTaskA.value,
+            #forkB: forkedTaskB.value
+          }, result: joinResult);
 
           for (var i = 0; i < 10; i++) {
             values.write(i);
@@ -1212,8 +1222,10 @@ void main() {
 
           execution.add(2);
 
-          yield Join(<dynamic, Task>{#forkA: forkedTaskA.value, #forkB: forkedTaskB.value},
-              result: joinResult);
+          yield Join(<dynamic, Task>{
+            #forkA: forkedTaskA.value,
+            #forkB: forkedTaskB.value
+          }, result: joinResult);
 
           for (var i = 0; i < 10; i++) {
             values.write(i);

--- a/test/forkjoinErrors_test.dart
+++ b/test/forkjoinErrors_test.dart
@@ -10,7 +10,8 @@ void main() {
 
       var caughtErrors = <dynamic>[];
 
-      var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createMiddleware(options: Options(onError: (dynamic e, String s) {
         caughtErrors.add(e);
       }));
       var store = createStore(sagaMiddleware);
@@ -25,7 +26,7 @@ void main() {
           actual.add('start parent');
           yield Fork(immediatelyFailingFork);
           actual.add('success parent');
-        }, Catch: (dynamic e) {
+        }, Catch: (dynamic e, StackTrace s) {
           actual.add('parent caught ${e}');
         });
       }
@@ -35,7 +36,7 @@ void main() {
           actual.add('start main');
           yield Call(genParent);
           actual.add('success main');
-        }, Catch: (dynamic e) {
+        }, Catch: (dynamic e, StackTrace s) {
           actual.add('main caught $e');
         });
       }
@@ -43,10 +44,16 @@ void main() {
       var task = sagaMiddleware.run(main);
 
       // saga should fails the parent if a forked function fails synchronously
-      expect(task.toFuture().then((dynamic value) => actual),
-          completion(['start main', 'start parent', 'main caught immediatelyFailingFork']));
+      expect(
+          task.toFuture().then((dynamic value) => actual),
+          completion([
+            'start main',
+            'start parent',
+            'main caught immediatelyFailingFork'
+          ]));
       // all errors are caught. so caughtErrors is empty
-      expect(task.toFuture().then((dynamic value) => caughtErrors), completion(<dynamic>[]));
+      expect(task.toFuture().then((dynamic value) => caughtErrors),
+          completion(<dynamic>[]));
     });
 
     test('saga sync fork failures: functions/error bubbling', () {
@@ -56,7 +63,8 @@ void main() {
 
       var exception = Exception('immediatelyFailingFork');
 
-      var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createMiddleware(options: Options(onError: (dynamic e, String s) {
         caughtErrors.add(e);
       }));
       var store = createStore(sagaMiddleware);
@@ -71,7 +79,7 @@ void main() {
           actual.add('start parent');
           yield Fork(immediatelyFailingFork);
           actual.add('success parent');
-        }, Catch: (dynamic e) {
+        }, Catch: (dynamic e, StackTrace s) {
           actual.add('parent caught ${e}');
         });
       }
@@ -81,7 +89,7 @@ void main() {
           actual.add('start main');
           yield Fork(genParent);
           actual.add('success main');
-        }, Catch: (dynamic e) {
+        }, Catch: (dynamic e, StackTrace s) {
           actual.add('main caught $e');
         });
       }
@@ -114,7 +122,7 @@ void main() {
           actual.add('start parent');
           yield Fork(genChild);
           actual.add('success parent');
-        }, Catch: (dynamic e) {
+        }, Catch: (dynamic e, StackTrace s) {
           actual.add('parent caught ${e}');
         });
       }
@@ -124,7 +132,7 @@ void main() {
           actual.add('start main');
           yield Call(genParent);
           actual.add('success main');
-        }, Catch: (dynamic e) {
+        }, Catch: (dynamic e, StackTrace s) {
           actual.add('main caught $e');
         });
       }
@@ -143,7 +151,8 @@ void main() {
 
       var exception = Exception('gen error');
 
-      var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createMiddleware(options: Options(onError: (dynamic e, String s) {
         caughtErrors.add(e);
       }));
       var store = createStore(sagaMiddleware);
@@ -160,7 +169,7 @@ void main() {
           yield Spawn(genChild, name: 'genChild', result: spawnedTask);
           actual.add('spawn ' + spawnedTask.value.meta.name);
           actual.add('success main');
-        }, Catch: (dynamic e) {
+        }, Catch: (dynamic e, StackTrace s) {
           actual.add('main caught $e');
         });
       }
@@ -177,7 +186,8 @@ void main() {
 
       var failError = Exception('fail error');
 
-      var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createMiddleware(options: Options(onError: (dynamic e, String s) {
         actual.add(e);
       }));
       var store = createStore(sagaMiddleware);
@@ -213,7 +223,8 @@ void main() {
       ]);
 
       // saga should not fail a parent with errors from detached fork
-      expect(f.then((dynamic value) => actual), completion([0, 1, 2, failError, 4]));
+      expect(f.then((dynamic value) => actual),
+          completion([0, 1, 2, failError, 4]));
     });
   });
 }

--- a/test/forkjoin_test.dart
+++ b/test/forkjoin_test.dart
@@ -22,7 +22,8 @@ void main() {
       var forkedTask2 = Result<Task>();
 
       var task = sagaMiddleware.run(() sync* {
-        yield Fork(subGen, args: <dynamic>[1], name: 'subGen', result: forkedTask);
+        yield Fork(subGen,
+            args: <dynamic>[1], name: 'subGen', result: forkedTask);
         yield Fork(inst.gen, result: forkedTask2);
       });
 
@@ -48,7 +49,8 @@ void main() {
       var comps = createArrayOfCompleters<dynamic>(2);
 
       Iterable<Effect> subGen(dynamic arg) sync* {
-        yield Call(() => comps[1].future); // will be resolved after the action-1
+        yield Call(
+            () => comps[1].future); // will be resolved after the action-1
         yield Return(arg);
       }
 
@@ -65,7 +67,8 @@ void main() {
         actual.add(result.value);
 
         var joinResult = JoinResult();
-        yield Join(<dynamic, Task>{#task: forkedTask.value}, result: joinResult);
+        yield Join(<dynamic, Task>{#task: forkedTask.value},
+            result: joinResult);
         actual.add(joinResult.value);
       }
 
@@ -126,10 +129,12 @@ void main() {
         actual.add(result.value);
 
         var joinResult = JoinResult();
-        yield Join(<dynamic, Task>{#task: forkedTask.value}, result: joinResult);
+        yield Join(<dynamic, Task>{#task: forkedTask.value},
+            result: joinResult);
         actual.add(joinResult.value);
 
-        yield Join(<dynamic, Task>{#task: forkedSyncTask.value}, result: joinResult);
+        yield Join(<dynamic, Task>{#task: forkedSyncTask.value},
+            result: joinResult);
         actual.add(joinResult.value);
       }
 
@@ -194,7 +199,8 @@ void main() {
       var task = sagaMiddleware.run(root);
 
       // parent task must wait for all forked tasks before terminating
-      expect(task.toFuture().then((dynamic value) => actual), completion([0, 2, 3, 1]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([0, 2, 3, 1]));
     });
 
     test('saga auto cancel forks on error', () {
@@ -275,7 +281,7 @@ void main() {
           var result = Result<dynamic>();
           yield Call(() => mainComp.future, result: result);
           actual.add(result.value);
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add(e);
           throw e;
         }, Finally: () sync* {
@@ -292,7 +298,7 @@ void main() {
           var result = Result<dynamic>();
           yield Call(main, result: result);
           actual.add(result.value);
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add('root caught $e');
         });
       }
@@ -413,7 +419,7 @@ void main() {
           actual.add(result.value);
 
           yield Cancel([forkedTask.value]);
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add('root caught $e');
         });
       }
@@ -462,10 +468,10 @@ void main() {
           var result = Result<dynamic>();
           yield Call(() => comps[idx].future, result: result);
           actual.add(result.value);
-        }, Catch: ((dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add(e);
           throw e;
-        }), Finally: () sync* {
+        }, Finally: () sync* {
           var cancelled = Result<bool>();
           yield Cancelled(result: cancelled);
           if (cancelled.value) {
@@ -531,7 +537,7 @@ void main() {
           var result = Result<dynamic>();
           yield Call(main, result: result);
           actual.add(result.value);
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add('root caught $e');
         });
       }
@@ -580,10 +586,10 @@ void main() {
           var result = Result<dynamic>();
           yield Call(() => comps[idx].future, result: result);
           actual.add(result.value);
-        }, Catch: ((dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add(e);
           throw e;
-        }), Finally: () sync* {
+        }, Finally: () sync* {
           var cancelled = Result<bool>();
           yield Cancelled(result: cancelled);
           if (cancelled.value) {
@@ -635,7 +641,7 @@ void main() {
           yield Call(() => mainComp.future, result: result);
           actual.add(result.value);
           yield Return('main returned');
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add(e);
           throw e;
         }, Finally: () sync* {
@@ -652,7 +658,7 @@ void main() {
           var result = Result<dynamic>();
           yield Call(main, result: result);
           actual.add(result.value);
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add('root caught $e');
         });
       }
@@ -697,8 +703,11 @@ void main() {
         var task3 = Result<Task>();
         yield Fork(worker, args: <dynamic>[2], result: task3);
 
-        yield Join(<dynamic, Task>{#task1: task1.value, #task2: task2.value, #task3: task3.value},
-            result: actual);
+        yield Join(<dynamic, Task>{
+          #task1: task1.value,
+          #task2: task2.value,
+          #task3: task3.value
+        }, result: actual);
       }
 
       var task = sagaMiddleware.run(root);

--- a/test/future_test.dart
+++ b/test/future_test.dart
@@ -20,15 +20,17 @@ void main() {
           actual.add(result.value);
 
           var result2 = Result<dynamic>();
-          yield Call(() => Future<int>.error(exceptionToBeCaught), result: result2);
+          yield Call(() => Future<int>.error(exceptionToBeCaught),
+              result: result2);
           actual.add(result2.value);
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add(e);
         });
       });
 
       // saga should handle future resolved/rejected values
-      expect(task.toFuture().then((dynamic value) => actual), completion([1, exceptionToBeCaught]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([1, exceptionToBeCaught]));
     });
   });
 }

--- a/test/helpers/store.dart
+++ b/test/helpers/store.dart
@@ -31,7 +31,8 @@ class AppState {
   int get hashCode => x.hashCode;
 
   @override
-  bool operator ==(Object other) => identical(this, other) || other is AppState && x == other.x;
+  bool operator ==(Object other) =>
+      identical(this, other) || other is AppState && x == other.x;
 
   dynamic toJson() => {
         'x': x,

--- a/test/helpers/utils.dart
+++ b/test/helpers/utils.dart
@@ -22,7 +22,9 @@ final value3 = SampleTestObject('Value3');
 
 SagaMiddleware createMiddleware({Options options}) {
   var sagaMiddleware = createSagaMiddleware(
-    options ?? Options(onError: (dynamic e, String s) {}), //don't log errors to console
+    options ??
+        Options(
+            onError: (dynamic e, String s) {}), //don't log errors to console
   );
   return sagaMiddleware;
 }

--- a/test/iterators_test.dart
+++ b/test/iterators_test.dart
@@ -43,7 +43,7 @@ void main() {
       Iterable<Effect> main() sync* {
         yield Try(() sync* {
           yield* child();
-        }, Catch: (dynamic e) {
+        }, Catch: (dynamic e, StackTrace s) {
           actual.add('caught $e');
         });
       }

--- a/test/middleware_test.dart
+++ b/test/middleware_test.dart
@@ -77,7 +77,7 @@ void main() {
 
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1); //no error. will not execute
       }, Finally: () sync* {
         execution.add(2);
@@ -138,7 +138,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
       });
 
@@ -171,7 +171,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
         throw sagaError;
       });
@@ -205,7 +205,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: (dynamic e) sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
         throw e;
       });
@@ -277,7 +277,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
       }, Finally: () sync* {
         execution.add(2);
@@ -312,7 +312,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
         throw sagaError;
       }, Finally: () sync* {
@@ -348,7 +348,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: (dynamic e) sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
         throw e;
       }, Finally: () sync* {
@@ -697,7 +697,7 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(2); //no error. will not execute
       }, Finally: () sync* {
         execution.add(3);
@@ -733,7 +733,7 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(2); //no error. will not execute
       }, Finally: () sync* {
         execution.add(3);
@@ -770,7 +770,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
         yield Return(value1);
         execution.add(2);
@@ -807,7 +807,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
         yield Return(value1);
         execution.add(2);
@@ -846,7 +846,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
         throw sagaError;
       }, Finally: () sync* {
@@ -885,7 +885,7 @@ void main() {
         execution.add(0);
         yield Cancel(); //must cancel from here
         execution.add(1);
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(2); //no error. will not execute
       }, Finally: () sync* {
         execution.add(3);
@@ -923,7 +923,7 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(2); //no error. will not execute
       }, Finally: () sync* {
         execution.add(3);
@@ -960,7 +960,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () sync* {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
         yield Cancel();
         execution.add(2);
@@ -1000,7 +1000,7 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(2);
       }, Finally: () {
         execution.add(3);
@@ -1036,7 +1036,7 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(2);
       }, Finally: () {
         execution.add(3);
@@ -1073,11 +1073,11 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(2);
-      }, Finally: () {
+      }, Finally: () sync* {
         execution.add(3);
-        return value2;
+        yield Return(value2);
       });
 
       expect(
@@ -1110,7 +1110,7 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(2);
       }, Finally: () {
         execution.add(3);
@@ -1146,7 +1146,7 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(2);
       }, Finally: () async {
         execution.add(3);
@@ -1182,11 +1182,11 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(2);
-      }, Finally: () async {
+      }, Finally: () sync* {
         execution.add(3);
-        return value2;
+        yield Return(value2);
       });
 
       expect(
@@ -1219,7 +1219,7 @@ void main() {
         execution.add(0);
         yield Return(value1);
         execution.add(1);
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(2);
       }, Finally: () async {
         execution.add(3);
@@ -1255,7 +1255,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(1);
       }, Finally: () {
         execution.add(2);
@@ -1290,7 +1290,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(1);
         throw sagaError;
       }, Finally: () {
@@ -1327,7 +1327,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) {
         execution.add(1);
         throw sagaError;
       }, Finally: () {
@@ -1364,7 +1364,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () async {
+      }, Catch: (dynamic e, StackTrace s) async {
         execution.add(1);
         throw sagaError;
       }, Finally: () async {
@@ -1401,7 +1401,7 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () async {
+      }, Catch: (dynamic e, StackTrace s) async {
         execution.add(1);
         throw sagaError;
       }, Finally: () {
@@ -1438,12 +1438,12 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
-        return value1;
-      }, Finally: () {
+        yield Return(value1);
+      }, Finally: () sync* {
         execution.add(2);
-        return value2;
+        yield Return(value2);
       });
 
       expect(
@@ -1475,12 +1475,12 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () async {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
-        return value1;
-      }, Finally: () {
+        yield Return(value1);
+      }, Finally: () sync* {
         execution.add(2);
-        return value2;
+        yield Return(value2);
       });
 
       expect(
@@ -1512,12 +1512,12 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         execution.add(0);
         throw exceptionToBeCaught;
-      }, Catch: () async {
+      }, Catch: (dynamic e, StackTrace s) sync* {
         execution.add(1);
-        return value1;
-      }, Finally: () async {
+        yield Return(value1);
+      }, Finally: () sync* {
         execution.add(2);
-        return value2;
+        yield Return(value2);
       });
 
       expect(
@@ -1554,7 +1554,8 @@ void main() {
       );
 
       //middleware.run must throw when executed before store property set
-      expect(() => sagaMiddleware.run(() sync* {}), throwsA(TypeMatcher<SagaStoreMustBeSet>()));
+      expect(() => sagaMiddleware.run(() sync* {}),
+          throwsA(TypeMatcher<SagaStoreMustBeSet>()));
 
       sagaMiddleware.setStore(store);
 
@@ -1573,8 +1574,8 @@ void main() {
       }
 
       //middleware.run must return a Task
-      expect(
-          sagaMiddleware.run(saga, args: <dynamic>[value1]), equals(TypeMatcher<Task<dynamic>>()));
+      expect(sagaMiddleware.run(saga, args: <dynamic>[value1]),
+          equals(TypeMatcher<Task<dynamic>>()));
 
       //middleware must run the Saga and provides it with the given arguments
       expect(actual, equals(value1));
@@ -1583,7 +1584,8 @@ void main() {
     test('middleware options', () {
       dynamic actual;
 
-      var sagaMiddleware = createSagaMiddleware(Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createSagaMiddleware(Options(onError: (dynamic e, String s) {
         actual = e;
       }));
       var store = createStore(sagaMiddleware);

--- a/test/monitoring_test.dart
+++ b/test/monitoring_test.dart
@@ -10,8 +10,8 @@ void main() {
       var effects = <int, Map<String, dynamic>>{};
       var actions = <dynamic>[];
 
-      var sagaMiddleware =
-          createMiddleware(options: Options(sagaMonitor: _TestMonitor(ids, effects, actions)));
+      var sagaMiddleware = createMiddleware(
+          options: Options(sagaMonitor: _TestMonitor(ids, effects, actions)));
       var store = createStore(sagaMiddleware);
       sagaMiddleware.setStore(store);
 
@@ -37,19 +37,28 @@ void main() {
 
       Iterable<Effect> main() sync* {
         yield Call(api, args: <dynamic>[0]);
-        yield Race(<String, Effect>{'action': Take(pattern: 'action'), 'call': Call(child)});
+        yield Race(<String, Effect>{
+          'action': Take(pattern: 'action'),
+          'call': Call(child)
+        });
       }
 
-      var task = sagaMiddleware.run(main, Catch: () {});
+      var task = sagaMiddleware.run(main, Catch: (dynamic e, StackTrace s) {});
 
-      expect(task.toFuture().then((dynamic value) => ids), completion([1, 2, 3, 4, 5, 6, 7]));
+      expect(task.toFuture().then((dynamic value) => ids),
+          completion([1, 2, 3, 4, 5, 6, 7]));
 
       //sagaMiddleware must notify the saga monitor of Effect creation and resolution
       expect(
           task.toFuture().then((dynamic value) => effects),
           completion({
             1: {'saga': main, 'args': null, 'namedArgs': null, 'result': task},
-            2: {'parentEffectId': 1, 'label': '', 'effect': TypeMatcher<Call>(), 'result': 'api1'},
+            2: {
+              'parentEffectId': 1,
+              'label': '',
+              'effect': TypeMatcher<Call>(),
+              'result': 'api1'
+            },
             3: {
               'parentEffectId': 1,
               'label': '',
@@ -68,7 +77,12 @@ void main() {
               'effect': TypeMatcher<Call>(),
               'error': exceptionToBeCaught
             },
-            6: {'parentEffectId': 5, 'label': '', 'effect': TypeMatcher<Call>(), 'result': 'api2'},
+            6: {
+              'parentEffectId': 5,
+              'label': '',
+              'effect': TypeMatcher<Call>(),
+              'result': 'api2'
+            },
             7: {
               'parentEffectId': 5,
               'label': '',
@@ -89,7 +103,7 @@ class _TestMonitor implements SagaMonitor {
   Map<int, Map<String, dynamic>> effects;
   List<dynamic> actions;
 
-  _TestMonitor(this.ids,this.effects, this.actions);
+  _TestMonitor(this.ids, this.effects, this.actions);
 
   @override
   void actionDispatched(dynamic action) {
@@ -112,7 +126,8 @@ class _TestMonitor implements SagaMonitor {
   }
 
   @override
-  void effectTriggered(int effectId, int parentEffectId, dynamic label, dynamic effect) {
+  void effectTriggered(
+      int effectId, int parentEffectId, dynamic label, dynamic effect) {
     ids.add(effectId);
     set(effectId, 'parentEffectId', parentEffectId);
     set(effectId, 'label', label);
@@ -120,11 +135,12 @@ class _TestMonitor implements SagaMonitor {
   }
 
   @override
-  void rootSagaStarted(int effectId, Function saga, List args, Map<Symbol, dynamic> namedArgs, String name) {
-  ids.add(effectId);
-  set(effectId, 'saga', saga);
-  set(effectId, 'args', args);
-  set(effectId, 'namedArgs', namedArgs);
+  void rootSagaStarted(int effectId, Function saga, List args,
+      Map<Symbol, dynamic> namedArgs, String name) {
+    ids.add(effectId);
+    set(effectId, 'saga', saga);
+    set(effectId, 'args', args);
+    set(effectId, 'namedArgs', namedArgs);
   }
 
   void set(int effectId, String key, dynamic value) {

--- a/test/onerror_test.dart
+++ b/test/onerror_test.dart
@@ -9,7 +9,8 @@ void main() {
       dynamic error;
       String stack;
 
-      var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createMiddleware(options: Options(onError: (dynamic e, String s) {
         error = e;
         stack = s;
       }));
@@ -26,20 +27,24 @@ void main() {
       expect(task.toFuture(), throwsA(exceptionToBeCaught));
 
       //middleware on error must be invoked
-      expect(task.toFuture().catchError((dynamic e) => error), completion(exceptionToBeCaught));
+      expect(task.toFuture().catchError((dynamic e) => error),
+          completion(exceptionToBeCaught));
 
       expect(
           task.toFuture().catchError((dynamic e) =>
               stack != null &&
-              stack.contains('#0      The above error occurred in task child') &&
+              stack
+                  .contains('#0      The above error occurred in task child') &&
               stack.contains('#1       created by main')),
           completion(true));
     });
 
-    test('saga onError is called for uncaught error (thrown Error instance)', () {
+    test('saga onError is called for uncaught error (thrown Error instance)',
+        () {
       dynamic actual;
 
-      var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createMiddleware(options: Options(onError: (dynamic e, String s) {
         actual = e;
       }));
       var store = createStore(sagaMiddleware);
@@ -54,17 +59,20 @@ void main() {
       expect(task.toFuture(), throwsA(exceptionToBeCaught));
 
       // saga passes thrown Error instance in onError handler
-      expect(task.toFuture().catchError((dynamic e) => e), completion(exceptionToBeCaught));
+      expect(task.toFuture().catchError((dynamic e) => e),
+          completion(exceptionToBeCaught));
 
       //middleware on error must be invoked
-      expect(task.toFuture().catchError((dynamic e) => actual), completion(exceptionToBeCaught));
+      expect(task.toFuture().catchError((dynamic e) => actual),
+          completion(exceptionToBeCaught));
     });
 
     test('saga onError is not called for caught errors', () {
       dynamic actual;
       dynamic caught;
 
-      var sagaMiddleware = createMiddleware(options: Options(onError: (dynamic e, String s) {
+      var sagaMiddleware =
+          createMiddleware(options: Options(onError: (dynamic e, String s) {
         actual = e;
       }));
       var store = createStore(sagaMiddleware);
@@ -73,8 +81,8 @@ void main() {
       var task = sagaMiddleware.run(() sync* {
         yield Call(() sync* {
           throw exceptionToBeCaught;
-        }, Catch: (dynamic error) {
-          caught = error;
+        }, Catch: (dynamic e, StackTrace s) {
+          caught = e;
         }, name: 'child');
       }, name: 'main');
 
@@ -82,7 +90,8 @@ void main() {
           completion(exceptionToBeCaught));
 
       //saga must not call onError
-      expect(task.toFuture().then<dynamic>((dynamic value) => actual), completion(null));
+      expect(task.toFuture().then<dynamic>((dynamic value) => actual),
+          completion(null));
     });
   });
 }

--- a/test/put_test.dart
+++ b/test/put_test.dart
@@ -40,8 +40,8 @@ void main() {
       var task = sagaMiddleware.run(genFn, args: <dynamic>['arg']);
 
       // saga must handle generator puts
-      expect(
-          task.toFuture().then((dynamic value) => actual), completion(<dynamic>[action1, action2]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(<dynamic>[action1, action2]));
     });
 
     test('saga put in a channel', () {
@@ -95,8 +95,8 @@ void main() {
       var task = sagaMiddleware.run(genFn, args: <dynamic>['arg']);
 
       // saga must handle async responses of generator put effects
-      expect(
-          task.toFuture().then((dynamic value) => actual), completion(<dynamic>[action1, action2]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(<dynamic>[action1, action2]));
     });
 
     test('saga error put\'s response handling', () {
@@ -122,8 +122,8 @@ void main() {
       Iterable<Effect> genFn(dynamic arg) sync* {
         yield Try(() sync* {
           yield Put(_Action(arg, true));
-        }, Catch: (dynamic error) sync* {
-          actual.add(error);
+        }, Catch: (dynamic e, StackTrace s) sync* {
+          actual.add(e);
         });
       }
 
@@ -147,15 +147,16 @@ void main() {
         yield Try(() sync* {
           error = Exception('error $arg');
           yield PutResolve(Future(() => throw error));
-        }, Catch: (dynamic error) sync* {
-          actual.add(error);
+        }, Catch: (dynamic e, StackTrace s) sync* {
+          actual.add(e);
         });
       }
 
       var task = sagaMiddleware.run(genFn, args: <dynamic>['arg']);
 
       // saga must bubble thrown errors of generator putResolve effects
-      expect(task.toFuture().then((dynamic value) => actual), completion(<dynamic>[error]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(<dynamic>[error]));
     });
 
     test('saga nested puts handling', () {
@@ -177,17 +178,20 @@ void main() {
       }
 
       Iterable<Effect> root() sync* {
-        yield Fork(genB); // forks genB first to be ready to take before genA starts putting
+        yield Fork(
+            genB); // forks genB first to be ready to take before genA starts putting
         yield Fork(genA);
       }
 
       var task = sagaMiddleware.run(root);
 
       // saga must order nested puts by executing them after the outer puts complete
-      expect(task.toFuture().then((dynamic value) => actual), completion(['put a', 'put b']));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(['put a', 'put b']));
     });
 
-    test('puts emitted while dispatching saga need not to cause stack overflow', () {
+    test('puts emitted while dispatching saga need not to cause stack overflow',
+        () {
       var channel = _TestChannel();
 
       var sagaMiddleware = createMiddleware(options: Options(channel: channel));
@@ -218,15 +222,16 @@ void main() {
         yield Try(() sync* {
           error = Exception('error $arg');
           yield PutResolve(Future(() => throw error));
-        }, Catch: (dynamic error) sync* {
-          actual.add(error);
+        }, Catch: (dynamic e, StackTrace s) sync* {
+          actual.add(e);
         });
       }
 
       var task = sagaMiddleware.run(genFn, args: <dynamic>['arg']);
 
       // saga must bubble thrown errors of generator putResolve effects
-      expect(task.toFuture().then((dynamic value) => actual), completion(<dynamic>[error]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(<dynamic>[error]));
     });
 
     test(
@@ -267,7 +272,8 @@ void main() {
 
       store.dispatch(_ActionA());
 
-      expect(task.toFuture().then((dynamic value) => actual), completion(['didn\'t get missed']));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion(['didn\'t get missed']));
     });
 
     test('END should reach tasks created after it gets dispatched', () {

--- a/test/retry_test.dart
+++ b/test/retry_test.dart
@@ -20,7 +20,10 @@ void main() {
           called++;
           actual.add(<dynamic>[arg1, called]);
           throw exceptionToBeCaught;
-        }, args: <dynamic>['a'], maxTries: 3, duration: Duration(milliseconds: delayMs));
+        },
+            args: <dynamic>['a'],
+            maxTries: 3,
+            duration: Duration(milliseconds: delayMs));
       });
 
       //should rethrow Error if failed more than the defined number of times
@@ -54,7 +57,10 @@ void main() {
             throw exceptionToBeCaught;
           }
           return returnedValue;
-        }, maxTries: 3, duration: Duration(milliseconds: delayMs), result: result);
+        },
+            maxTries: 3,
+            duration: Duration(milliseconds: delayMs),
+            result: result);
       });
 
       // should return a result of called function

--- a/test/scheduler_test.dart
+++ b/test/scheduler_test.dart
@@ -17,7 +17,8 @@ void main() {
       expect(actual, equals(['1', '2', '3']));
     });
 
-    test('scheduler when suspended queues up and executes all tasks on flush', () {
+    test('scheduler when suspended queues up and executes all tasks on flush',
+        () {
       final actual = <String>[];
       immediately(() {
         asap(() {

--- a/test/select_test.dart
+++ b/test/select_test.dart
@@ -66,7 +66,8 @@ void main() {
       ]);
 
       // should resolve getState and select effects
-      expect(task.toFuture().then((dynamic value) => actual), completion([0, 0, 2, 1, 1]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([0, 0, 2, 1, 1]));
     });
 
     test('select test', () {

--- a/test/spawn_test.dart
+++ b/test/spawn_test.dart
@@ -102,7 +102,10 @@ void main() {
             ]));
 
         //spawned task finished after main task
-        expect(spawnedTask.value.toFuture().then((dynamic value) => taskCompletion),
+        expect(
+            spawnedTask.value
+                .toFuture()
+                .then((dynamic value) => taskCompletion),
             completion([1, 0]));
 
         async.elapse(Duration(milliseconds: 100));
@@ -193,7 +196,9 @@ void main() {
           execution.add(2);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
         task.toFuture().then((dynamic v) => taskCompletion.add(1));
 
         expect(
@@ -307,16 +312,18 @@ void main() {
             ]));
 
         expect(
-            spawnedTaskA.value.toFuture().catchError((dynamic error) => <dynamic>[
-                  error,
-                  spawnedTaskA.value.result,
-                  spawnedTaskA.value.isRunning,
-                  spawnedTaskA.value.isCancelled,
-                  spawnedTaskA.value.isAborted,
-                  execution,
-                  taskCompletion,
-                  values.toString()
-                ]),
+            spawnedTaskA.value
+                .toFuture()
+                .catchError((dynamic error) => <dynamic>[
+                      error,
+                      spawnedTaskA.value.result,
+                      spawnedTaskA.value.isRunning,
+                      spawnedTaskA.value.isCancelled,
+                      spawnedTaskA.value.isAborted,
+                      execution,
+                      taskCompletion,
+                      values.toString()
+                    ]),
             completion([
               exceptionToBeCaught,
               null,
@@ -361,7 +368,9 @@ void main() {
           }
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
         task
             .toFuture()
             .then((dynamic v) => taskCompletion.add(1))
@@ -448,7 +457,9 @@ void main() {
           execution.add(2);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
         task.toFuture().then((dynamic v) => taskCompletion.add(1));
 
         expect(
@@ -540,8 +551,12 @@ void main() {
           execution.add(3);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
-        spawnedTaskB.value.toFuture().then((dynamic v) => taskCompletion.add(1));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskB.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(1));
         task.toFuture().then((dynamic v) => taskCompletion.add(2));
 
         expect(
@@ -657,8 +672,12 @@ void main() {
           execution.add(3);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
-        spawnedTaskB.value.toFuture().then((dynamic v) => taskCompletion.add(1));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskB.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(1));
         task.toFuture().then((dynamic v) => taskCompletion.add(2));
 
         expect(
@@ -774,8 +793,12 @@ void main() {
           execution.add(3);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
-        spawnedTaskB.value.toFuture().then((dynamic v) => taskCompletion.add(1));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskB.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(1));
         task.toFuture().then((dynamic v) => taskCompletion.add(2));
 
         expect(
@@ -891,8 +914,12 @@ void main() {
           execution.add(3);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
-        spawnedTaskB.value.toFuture().then((dynamic v) => taskCompletion.add(1));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskB.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(1));
         task.toFuture().then((dynamic v) => taskCompletion.add(2));
 
         expect(
@@ -1000,7 +1027,8 @@ void main() {
 
           execution.add(2);
 
-          yield Join(<dynamic, Task>{#spawnA: spawnedTaskA.value}, result: joinResult);
+          yield Join(<dynamic, Task>{#spawnA: spawnedTaskA.value},
+              result: joinResult);
 
           for (var i = 0; i < 10; i++) {
             values.write(i);
@@ -1011,8 +1039,12 @@ void main() {
           execution.add(3);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
-        spawnedTaskB.value.toFuture().then((dynamic v) => taskCompletion.add(1));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskB.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(1));
         task.toFuture().then((dynamic v) => taskCompletion.add(2));
 
         expect(
@@ -1123,8 +1155,10 @@ void main() {
 
           execution.add(2);
 
-          yield Join(<dynamic, Task>{#spawnA: spawnedTaskA.value, #spawnB: spawnedTaskB.value},
-              result: joinResult);
+          yield Join(<dynamic, Task>{
+            #spawnA: spawnedTaskA.value,
+            #spawnB: spawnedTaskB.value
+          }, result: joinResult);
 
           for (var i = 0; i < 10; i++) {
             values.write(i);
@@ -1135,8 +1169,12 @@ void main() {
           execution.add(3);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
-        spawnedTaskB.value.toFuture().then((dynamic v) => taskCompletion.add(1));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskB.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(1));
         task.toFuture().then((dynamic v) => taskCompletion.add(2));
 
         expect(
@@ -1253,8 +1291,10 @@ void main() {
 
           execution.add(4);
 
-          yield Join(<dynamic, Task>{#spawnA: spawnedTaskA.value, #spawnB: spawnedTaskB.value},
-              result: joinResult);
+          yield Join(<dynamic, Task>{
+            #spawnA: spawnedTaskA.value,
+            #spawnB: spawnedTaskB.value
+          }, result: joinResult);
 
           for (var i = 0; i < 10; i++) {
             values.write(i);
@@ -1267,8 +1307,12 @@ void main() {
           execution.add(6);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
-        spawnedTaskB.value.toFuture().then((dynamic v) => taskCompletion.add(1));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskB.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(1));
         task.toFuture().then((dynamic v) => taskCompletion.add(2));
 
         //joined task cancel will cancel root also
@@ -1381,8 +1425,10 @@ void main() {
 
           execution.add(2);
 
-          yield Join(<dynamic, Task>{#spawnA: spawnedTaskA.value, #spawnB: spawnedTaskB.value},
-              result: joinResult);
+          yield Join(<dynamic, Task>{
+            #spawnA: spawnedTaskA.value,
+            #spawnB: spawnedTaskB.value
+          }, result: joinResult);
 
           for (var i = 0; i < 10; i++) {
             values.write(i);
@@ -1393,8 +1439,12 @@ void main() {
           execution.add(3);
         });
 
-        spawnedTaskA.value.toFuture().then((dynamic v) => taskCompletion.add(0));
-        spawnedTaskB.value.toFuture().then((dynamic v) => taskCompletion.add(1));
+        spawnedTaskA.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(0));
+        spawnedTaskB.value
+            .toFuture()
+            .then((dynamic v) => taskCompletion.add(1));
         task.toFuture().then((dynamic v) => taskCompletion.add(2));
 
         //joined task cancel will cancel root also

--- a/test/takeEvery_test.dart
+++ b/test/takeEvery_test.dart
@@ -17,7 +17,10 @@ void main() {
 
         yield TakeEvery((dynamic arg1, dynamic arg2, {dynamic action}) sync* {
           actual.add(<dynamic>[arg1, arg2, action.payload]);
-        }, args: <dynamic>['a1', 'a2'], pattern: TestActionA, result: forkedTask);
+        },
+            args: <dynamic>['a1', 'a2'],
+            pattern: TestActionA,
+            result: forkedTask);
         yield Take(pattern: TestActionCancel);
         yield Cancel([forkedTask.value]);
       });
@@ -74,7 +77,8 @@ void main() {
 
       expect(
           task.toFuture().then((dynamic value) => [
-                forkedTask.value.isRunning, // should finish takeEvery task on END
+                forkedTask
+                    .value.isRunning, // should finish takeEvery task on END
                 called // should not call function if finished with END
               ]),
           completion([false, false]));

--- a/test/takeLatest_test.dart
+++ b/test/takeLatest_test.dart
@@ -20,7 +20,10 @@ void main() {
           var result = Result<dynamic>();
           yield Call(() => completers[idx].future, result: result);
           actual.add(<dynamic>[arg1, arg2, result.value]);
-        }, args: <dynamic>['a1', 'a2'], pattern: TestActionA, result: forkedTask);
+        },
+            args: <dynamic>['a1', 'a2'],
+            pattern: TestActionA,
+            result: forkedTask);
         yield Take(pattern: TestActionCancel);
         yield Cancel([forkedTask.value]);
       });
@@ -64,7 +67,7 @@ void main() {
       sagaMiddleware.setStore(store);
 
       var task = sagaMiddleware.run(() sync* {
-        yield TakeLatest(() sync* {
+        yield TakeLatest((dynamic action) sync* {
           called = true;
         }, pattern: TestActionA, result: forkedTask);
       });
@@ -75,7 +78,8 @@ void main() {
 
       expect(
           task.toFuture().then((dynamic value) => [
-                forkedTask.value.isRunning, // should finish takeLatest task on END
+                forkedTask
+                    .value.isRunning, // should finish takeLatest task on END
                 called // should not call function if finished with END
               ]),
           completion([false, false]));

--- a/test/takeLeading_test.dart
+++ b/test/takeLeading_test.dart
@@ -20,7 +20,10 @@ void main() {
           var result = Result<dynamic>();
           yield Call(() => completers[idx].future, result: result);
           actual.add(<dynamic>[arg1, arg2, result.value]);
-        }, args: <dynamic>['a1', 'a2'], pattern: TestActionA, result: forkedTask);
+        },
+            args: <dynamic>['a1', 'a2'],
+            pattern: TestActionA,
+            result: forkedTask);
         yield Take(pattern: TestActionCancel);
         yield Cancel([forkedTask.value]);
       });
@@ -63,7 +66,7 @@ void main() {
       sagaMiddleware.setStore(store);
 
       var task = sagaMiddleware.run(() sync* {
-        yield TakeLeading(() sync* {
+        yield TakeLeading(({dynamic action}) sync* {
           called = true;
         }, pattern: TestActionA, result: forkedTask);
       });
@@ -73,7 +76,8 @@ void main() {
 
       expect(
           task.toFuture().then((dynamic value) => [
-                forkedTask.value.isRunning, // should finish takeLatest task on END
+                forkedTask
+                    .value.isRunning, // should finish takeLatest task on END
                 called // should not call function if finished with END
               ]),
           completion([false, false]));

--- a/test/take_sync_test.dart
+++ b/test/take_sync_test.dart
@@ -96,7 +96,8 @@ void main() {
 
       Iterable<Effect> root() sync* {
         var resultAll = AllResult();
-        yield All(<dynamic, Effect>{#a1: Take(pattern: _a1), #a2: Take(pattern: _a2)},
+        yield All(
+            <dynamic, Effect>{#a1: Take(pattern: _a1), #a2: Take(pattern: _a2)},
             result: resultAll);
         actual.add(resultAll.value);
       }
@@ -271,7 +272,8 @@ void main() {
 
         yield Put(TestActionD('ack-2'));
 
-        yield Take(channel: channel, pattern: _neverHappeningAction, result: result);
+        yield Take(
+            channel: channel, pattern: _neverHappeningAction, result: result);
       }
 
       sagaMiddleware.run(root);
@@ -356,7 +358,8 @@ void main() {
       var task = sagaMiddleware.run(root);
 
       // Sagas must take actions from each other (via buffered channel)
-      expect(task.toFuture().then((dynamic value) => actual), completion([1, 2, 3]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([1, 2, 3]));
     });
 
     test('inter-saga send/acknowledge handling', () {
@@ -551,7 +554,10 @@ void main() {
       }
 
       Iterable<Effect> takeTest2({dynamic action}) sync* {
-        yield All(<dynamic, Effect>{#fork1: Fork(forkedPut1), #fork2: Fork(forkedPut2)});
+        yield All(<dynamic, Effect>{
+          #fork1: Fork(forkedPut1),
+          #fork2: Fork(forkedPut2)
+        });
       }
 
       Iterable<Effect> root() sync* {
@@ -567,7 +573,8 @@ void main() {
       store.dispatch(End);
 
       // Sagas must take actions from each forked tasks doing Sync puts
-      expect(task.toFuture().then((dynamic value) => actual), completion([1, 2, 3]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([1, 2, 3]));
     });
 
     test('deeply nested forks/puts', () {
@@ -621,7 +628,9 @@ void main() {
 
           yield Put(_PING(newVal));
 
-          yield Take(pattern: (dynamic message) => message is _ACK && message.val == newVal);
+          yield Take(
+              pattern: (dynamic message) =>
+                  message is _ACK && message.val == newVal);
         }
 
         yield Put(_ACK(action.val as int));
@@ -639,7 +648,8 @@ void main() {
       store.dispatch(End);
 
       // Sagas must take actions from each forked tasks doing Sync puts
-      expect(task.toFuture().then((dynamic value) => actual), completion([1, 1]));
+      expect(
+          task.toFuture().then((dynamic value) => actual), completion([1, 1]));
     });
 
     test('put causing sync dispatch response in store subscriber', () {
@@ -663,7 +673,9 @@ void main() {
         while (true) {
           var race = RaceResult();
 
-          yield Race(<dynamic, Effect>{#a: Take(pattern: _a), #b: Take(pattern: _b)}, result: race);
+          yield Race(
+              <dynamic, Effect>{#a: Take(pattern: _a), #b: Take(pattern: _b)},
+              result: race);
 
           actual.add(race.keyValue);
 
@@ -684,10 +696,13 @@ void main() {
       store.dispatch(_a());
 
       //Sagas can't miss actions dispatched by store subscribers during put handling
-      expect(Future(() => actual), completion(([TypeMatcher<_a>(), TypeMatcher<_b>()])));
+      expect(Future(() => actual),
+          completion(([TypeMatcher<_a>(), TypeMatcher<_b>()])));
     });
 
-    test('action dispatched in root saga should get scheduled and taken by a "sibling" take', () {
+    test(
+        'action dispatched in root saga should get scheduled and taken by a "sibling" take',
+        () {
       var sagaMiddleware = createSagaMiddleware();
 
       var store = Store<_State2>(
@@ -705,7 +720,7 @@ void main() {
       sagaMiddleware.run(() sync* {
         yield All(<dynamic, Effect>{
           #put: Put(_FIRST()),
-          #takeEvery: TakeEvery(() sync* {
+          #takeEvery: TakeEvery(({dynamic action}) sync* {
             yield Put(_SECOND());
           }, pattern: _FIRST)
         });
@@ -716,7 +731,8 @@ void main() {
           completion(([TypeMatcher<_FIRST>(), TypeMatcher<_SECOND>()])));
     });
 
-    test('action dispatched synchronously in forked task should be taken a following sync take',
+    test(
+        'action dispatched synchronously in forked task should be taken a following sync take',
         () {
       var actual = <dynamic>[];
 
@@ -749,7 +765,8 @@ void main() {
         actual.add(result.value);
       });
 
-      expect(task.toFuture().then((dynamic value) => actual), completion([action]));
+      expect(task.toFuture().then((dynamic value) => actual),
+          completion([action]));
     });
   });
 }

--- a/test/take_test.dart
+++ b/test/take_test.dart
@@ -19,33 +19,44 @@ void main() {
           yield Take(result: result); // take all actions
           actual.add(result.value);
 
-          yield Take(pattern: _Action1, result: result); // take only actions of type 'action-1'
-          actual.add(result.value);
-
-          yield Take(pattern: [_Action2, _Action2222], result: result); // take either type
+          yield Take(
+              pattern: _Action1,
+              result: result); // take only actions of type 'action-1'
           actual.add(result.value);
 
           yield Take(
-              pattern: (dynamic action) => action is _ActionP && action.isAction,
+              pattern: [_Action2, _Action2222],
+              result: result); // take either type
+          actual.add(result.value);
+
+          yield Take(
+              pattern: (dynamic action) =>
+                  action is _ActionP && action.isAction,
               result: result); // take if match predicate
           actual.add(result.value);
 
           yield Take(pattern: [
             _Action3,
-            (dynamic action) => action is _ActionWP && action.isMixedWithPredicate
+            (dynamic action) =>
+                action is _ActionWP && action.isMixedWithPredicate
           ], result: result); // take if match any from the mixed array
           actual.add(result.value);
 
           yield Take(pattern: [
             _Action3,
-            (dynamic action) => action is _ActionWP && action.isMixedWithPredicate
+            (dynamic action) =>
+                action is _ActionWP && action.isMixedWithPredicate
           ], result: result); // take if match any from the mixed array
           actual.add(result.value);
 
-          yield Take(pattern: 'Symbol', result: result); // take only actions of a Symbol type
+          yield Take(
+              pattern: 'Symbol',
+              result: result); // take only actions of a Symbol type
           actual.add(result.value);
 
-          yield Take(pattern: _NeverHappeningAction, result: result); //  should get END
+          yield Take(
+              pattern: _NeverHappeningAction,
+              result: result); //  should get END
           actual.add(result.value);
         }, Finally: () {
           actual.add('auto ended');
@@ -114,7 +125,8 @@ void main() {
       ]);
 
       // saga must fulfill take Effects from a provided channel
-      expect(f.then((dynamic value) => actual), completion([1, 2, 3, 4, End, End]));
+      expect(f.then((dynamic value) => actual),
+          completion([1, 2, 3, 4, End, End]));
     });
 
     test('saga take from eventChannel', () {
@@ -144,7 +156,7 @@ void main() {
 
           yield Take(channel: channel, result: result);
           actual.add(result.value);
-        }, Catch: (dynamic e) sync* {
+        }, Catch: (dynamic e, StackTrace s) sync* {
           actual.add('in-catch-block');
           actual.add(e);
         });
@@ -158,8 +170,10 @@ void main() {
       ]);
 
       // saga must take payloads from the eventChannel, and errors from eventChannel will make the saga jump to the catch block
-      expect(f.then((dynamic value) => actual),
-          completion(['action-1', 'action-2', 'in-catch-block', exceptionToBeCaught]));
+      expect(
+          f.then((dynamic value) => actual),
+          completion(
+              ['action-1', 'action-2', 'in-catch-block', exceptionToBeCaught]));
     });
 
     test('take test', () {
@@ -286,13 +300,15 @@ void main() {
             completion([exceptionToBeCaught, null, false, false, true]));
 
         expect(
-            forkedTaskA.value.toFuture().catchError((dynamic error) => <dynamic>[
-                  error,
-                  forkedTaskA.value.result,
-                  forkedTaskA.value.isRunning,
-                  forkedTaskA.value.isCancelled,
-                  forkedTaskA.value.isAborted,
-                ]),
+            forkedTaskA.value
+                .toFuture()
+                .catchError((dynamic error) => <dynamic>[
+                      error,
+                      forkedTaskA.value.result,
+                      forkedTaskA.value.isRunning,
+                      forkedTaskA.value.isCancelled,
+                      forkedTaskA.value.isAborted,
+                    ]),
             completion([exceptionToBeCaught, null, false, false, true]));
         async.elapse(Duration(milliseconds: 100));
       });
@@ -389,7 +405,8 @@ void main() {
           takes.add(result.value.payload);
 
           yield Take(
-              pattern: (dynamic action) => action is TestActionA && action.payload == 4,
+              pattern: (dynamic action) =>
+                  action is TestActionA && action.payload == 4,
               result: result);
           takes.add(result.value.payload);
 

--- a/test/throttle_test.dart
+++ b/test/throttle_test.dart
@@ -73,9 +73,12 @@ void main() {
         sagaMiddleware.setStore(store);
 
         var mainTask = sagaMiddleware.run(() sync* {
-          yield Throttle(() {
+          yield Throttle(({dynamic action}) {
             called = true;
-          }, duration: Duration(milliseconds: delayMs), pattern: TestActionA, result: task);
+          },
+              duration: Duration(milliseconds: delayMs),
+              pattern: TestActionA,
+              result: task);
         });
 
         store.dispatch(End);


### PR DESCRIPTION
flutter web build errors fixed. After minification the function closures are changing.
In order to avoid dart mirrors usage (also not avaliable) some changes are made.
Codes are written at previous versions of the library must be migrated to this version.