### PR TITLE
upd Race result argument is required for Race example

### DIFF
--- a/doc/advanced/RacingEffects.md
+++ b/doc/advanced/RacingEffects.md
@@ -14,7 +14,7 @@ fetchPostsWithTimeout() sync* {
   yield Race({
     #posts: Call(fetchApi, args: ['/posts']),
     #timeout: Delay(Duration(seconds: 1))
-  });
+  }, result: result);
 
   if (result.key == #posts) {
     yield Put(PostsReceived(posts));


### PR DESCRIPTION
Even if there is not shown correct way to get posts, race result must be passed to Race effect